### PR TITLE
Fix type serialization issues with PostgreSQL parameter binding

### DIFF
--- a/crates/mssql-pg-migrate/src/lib.rs
+++ b/crates/mssql-pg-migrate/src/lib.rs
@@ -41,5 +41,5 @@ pub use error::{MigrateError, Result};
 pub use orchestrator::{MigrationResult, Orchestrator};
 pub use source::{MssqlPool, Table};
 pub use state::MigrationState;
-pub use target::{PgPool, SqlValue};
+pub use target::{PgPool, SqlNullType, SqlValue};
 pub use transfer::{TransferConfig, TransferEngine, TransferJob, TransferStats};

--- a/crates/mssql-pg-migrate/src/transfer/mod.rs
+++ b/crates/mssql-pg-migrate/src/transfer/mod.rs
@@ -194,7 +194,11 @@ impl TransferEngine {
 
         stats.rows = rows_written;
         stats.write_time = write_time;
-        stats.scan_time = start.elapsed() - stats.query_time - stats.write_time;
+        // Use saturating_sub to avoid overflow if query_time + write_time > elapsed
+        let total_elapsed = start.elapsed();
+        stats.scan_time = total_elapsed
+            .saturating_sub(stats.query_time)
+            .saturating_sub(stats.write_time);
         stats.completed = true;
 
         info!(


### PR DESCRIPTION
## Summary

- Fix tokio-postgres trait object serialization issues by using SQL literal values instead of parameterized queries
- Add typed NULL handling with `SqlNullType` enum to preserve column type information
- Fix MSSQL schema extraction compatibility issues (NUMERIC_PRECISION casting, STUFF/FOR XML PATH)
- Fix duration overflow panic with `saturating_sub`
- Cast MAX() results to bigint for consistent type handling

## Performance Results

Tested with Stack Overflow 2010 dataset (~19.3M rows across 9 tables):

| Mode | Rows | Duration | Throughput |
|------|------|----------|------------|
| drop_recreate | 19,310,703 | 215.9s | 89,439 rows/s |
| truncate | 19,310,703 | ~210s | ~92K rows/s |
| upsert | 19,310,704 | 252.6s | 76,445 rows/s |

## Changes

### target/mod.rs
- Add `SqlNullType` enum for typed NULL values
- Replace `write_chunk()` parameterized queries with `build_insert_sql_literals()`
- Replace `upsert_chunk()` parameterized queries with `build_upsert_sql_literals()`
- Add `sql_value_to_literal()` for proper SQL escaping (handles strings, datetimes, bytea, etc.)
- Fix `sync_identity_sequence()` to cast MAX() to bigint

### source/mod.rs
- Fix `load_columns()`: Use CAST for NUMERIC_PRECISION to avoid U8 type errors
- Fix `load_indexes()`: Use STUFF/FOR XML PATH instead of STRING_AGG for SQL Server compatibility
- Add typed NULL handling in `convert_row_value()`

### transfer/mod.rs
- Fix duration overflow with `saturating_sub` when calculating scan_time

## Test plan

- [x] Test drop_recreate mode with full dataset reload
- [x] Test truncate mode with existing tables
- [x] Test upsert mode with data updates (100 modified rows + 1 new row)
- [x] Verify upsert correctly detects and applies changes
- [x] Verify new rows are inserted
- [x] Verify all data types transfer correctly (datetime, varchar, int, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)