### PR TITLE
feat: staging table upsert for 2.3x faster performance

### DIFF
--- a/crates/mssql-pg-migrate/src/orchestrator/mod.rs
+++ b/crates/mssql-pg-migrate/src/orchestrator/mod.rs
@@ -75,8 +75,6 @@ impl Orchestrator {
             max_conns,
             config.migration.get_copy_buffer_rows(),
             config.migration.use_binary_copy,
-            config.migration.get_upsert_batch_size(),
-            config.migration.get_upsert_parallel_tasks(),
         )
         .await?;
 


### PR DESCRIPTION
## Summary

- Replace row-by-row `INSERT...ON CONFLICT` with staging table approach
- Uses fast binary COPY to load staging table, then single MERGE statement
- Removes unused parallel batching code (no longer needed)

## How it works

```
1. CREATE TEMP TABLE _staging_xxx (LIKE target INCLUDING DEFAULTS)
2. COPY rows → staging (binary format, ~200K rows/sec)
3. INSERT INTO target SELECT * FROM staging ON CONFLICT DO UPDATE
4. DROP TABLE staging
```

## Performance

| Approach | Throughput | Duration (19M rows) |
|----------|-----------|---------------------|
| Row-by-row (before) | 59K rows/sec | 329s |
| **Staging table (after)** | **134K rows/sec** | **144s** |

**2.3x faster** with same correctness (all row counts validated).

## Batch size control

The `chunk_size` config option controls how many rows are merged per staging table operation (default: ~100K auto-tuned based on RAM).

## Test plan

- [x] Build succeeds with no warnings
- [x] Upsert migration completes successfully
- [x] Row count validation passes (all 10 tables match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)