### PR TITLE
feat: implement --progress flag for JSON progress updates

### DIFF
--- a/crates/mssql-pg-migrate/src/orchestrator/mod.rs
+++ b/crates/mssql-pg-migrate/src/orchestrator/mod.rs
@@ -146,6 +146,14 @@ pub struct ProgressUpdate {
     pub current_table: Option<String>,
 }
 
+/// Write a progress update as JSON to stderr.
+fn emit_progress_json(update: &ProgressUpdate) {
+    if let Ok(json) = serde_json::to_string(update) {
+        let mut stderr = std::io::stderr().lock();
+        let _ = writeln!(stderr, "{}", json);
+    }
+}
+
 /// Thread-safe progress tracker for concurrent table transfers.
 #[derive(Debug)]
 struct ProgressTracker {
@@ -172,34 +180,36 @@ impl ProgressTracker {
         self.tables_completed.fetch_add(1, Ordering::Relaxed);
     }
 
+    fn increment_table_count(&self) {
+        self.tables_completed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn get_rows_per_second(&self) -> i64 {
+        let elapsed = self.started_at.elapsed().as_secs_f64();
+        let rows = self.rows_transferred.load(Ordering::Relaxed);
+        if elapsed > 0.0 {
+            (rows as f64 / elapsed) as i64
+        } else {
+            0
+        }
+    }
+
     fn emit(&self, phase: &str, current_table: Option<String>) {
         if !self.progress_enabled {
             return;
         }
-
-        let elapsed = self.started_at.elapsed().as_secs_f64();
-        let rows = self.rows_transferred.load(Ordering::Relaxed);
-        let rows_per_second = if elapsed > 0.0 {
-            (rows as f64 / elapsed) as i64
-        } else {
-            0
-        };
 
         let update = ProgressUpdate {
             timestamp: Utc::now(),
             phase: phase.to_string(),
             tables_completed: self.tables_completed.load(Ordering::Relaxed),
             tables_total: self.tables_total,
-            rows_transferred: rows,
-            rows_per_second,
+            rows_transferred: self.rows_transferred.load(Ordering::Relaxed),
+            rows_per_second: self.get_rows_per_second(),
             current_table,
         };
 
-        // Write JSON line to stderr
-        if let Ok(json) = serde_json::to_string(&update) {
-            let mut stderr = std::io::stderr().lock();
-            let _ = writeln!(stderr, "{}", json);
-        }
+        emit_progress_json(&update);
     }
 }
 
@@ -259,10 +269,7 @@ impl Orchestrator {
             current_table: None,
         };
 
-        if let Ok(json) = serde_json::to_string(&update) {
-            let mut stderr = std::io::stderr().lock();
-            let _ = writeln!(stderr, "{}", json);
-        }
+        emit_progress_json(&update);
     }
 
     /// Load existing state for resume.
@@ -869,6 +876,18 @@ impl Orchestrator {
                     // Track partition completion even on failure
                     if is_partitioned {
                         *partition_completed.entry(base_table.clone()).or_insert(0) += 1;
+                        let completed = partition_completed[&base_table];
+                        let total = partition_counts[&base_table];
+
+                        // Emit progress when all partitions are done (even with failures)
+                        if completed == total {
+                            progress.increment_table_count();
+                            progress.emit("transferring", Some(base_table.clone()));
+                        }
+                    } else {
+                        // Non-partitioned table failed
+                        progress.increment_table_count();
+                        progress.emit("transferring", Some(base_table.clone()));
                     }
                 }
                 Err(e) => {
@@ -881,6 +900,18 @@ impl Orchestrator {
                     // Track partition completion even on panic
                     if is_partitioned {
                         *partition_completed.entry(base_table.clone()).or_insert(0) += 1;
+                        let completed = partition_completed[&base_table];
+                        let total = partition_counts[&base_table];
+
+                        // Emit progress when all partitions are done (even with panics)
+                        if completed == total {
+                            progress.increment_table_count();
+                            progress.emit("transferring", Some(base_table.clone()));
+                        }
+                    } else {
+                        // Non-partitioned table panicked
+                        progress.increment_table_count();
+                        progress.emit("transferring", Some(base_table.clone()));
                     }
                 }
             }
@@ -1302,5 +1333,91 @@ mod tests {
         assert!(json.contains("\"error\":\"Schema extraction failed\""));
         assert!(json.contains("\"error_type\":\"schema_extraction\""));
         assert!(json.contains("\"recoverable\":false"));
+    }
+
+    // ProgressTracker tests
+    #[test]
+    fn test_progress_tracker_new() {
+        let tracker = ProgressTracker::new(10, true);
+        assert_eq!(tracker.tables_total, 10);
+        assert_eq!(tracker.tables_completed.load(Ordering::Relaxed), 0);
+        assert_eq!(tracker.rows_transferred.load(Ordering::Relaxed), 0);
+        assert!(tracker.progress_enabled);
+    }
+
+    #[test]
+    fn test_progress_tracker_complete_table() {
+        let tracker = ProgressTracker::new(5, false);
+
+        tracker.complete_table(1000);
+        assert_eq!(tracker.tables_completed.load(Ordering::Relaxed), 1);
+        assert_eq!(tracker.rows_transferred.load(Ordering::Relaxed), 1000);
+
+        tracker.complete_table(2000);
+        assert_eq!(tracker.tables_completed.load(Ordering::Relaxed), 2);
+        assert_eq!(tracker.rows_transferred.load(Ordering::Relaxed), 3000);
+    }
+
+    #[test]
+    fn test_progress_tracker_increment_table_count() {
+        let tracker = ProgressTracker::new(3, false);
+
+        tracker.increment_table_count();
+        assert_eq!(tracker.tables_completed.load(Ordering::Relaxed), 1);
+        assert_eq!(tracker.rows_transferred.load(Ordering::Relaxed), 0);
+
+        tracker.increment_table_count();
+        assert_eq!(tracker.tables_completed.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn test_progress_tracker_rows_per_second() {
+        let tracker = ProgressTracker::new(1, false);
+
+        // Initially should be 0
+        assert_eq!(tracker.get_rows_per_second(), 0);
+
+        // Add some rows and check calculation
+        tracker.complete_table(10000);
+        // Since time has passed, rows_per_second should be > 0
+        // We can't test exact value due to timing, but it should be reasonable
+        let rps = tracker.get_rows_per_second();
+        assert!(rps >= 0); // At minimum it's non-negative
+    }
+
+    #[test]
+    fn test_progress_tracker_disabled_emit() {
+        // When progress_enabled is false, emit should not panic
+        let tracker = ProgressTracker::new(5, false);
+        tracker.complete_table(1000);
+        // This should be a no-op and not panic
+        tracker.emit("transferring", Some("test_table".to_string()));
+    }
+
+    #[test]
+    fn test_progress_tracker_concurrent_updates() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let tracker = Arc::new(ProgressTracker::new(100, false));
+        let mut handles = vec![];
+
+        // Spawn 10 threads, each completing 10 tables with 100 rows each
+        for _ in 0..10 {
+            let t = tracker.clone();
+            handles.push(thread::spawn(move || {
+                for _ in 0..10 {
+                    t.complete_table(100);
+                }
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // Should have 100 tables completed with 10000 total rows
+        assert_eq!(tracker.tables_completed.load(Ordering::Relaxed), 100);
+        assert_eq!(tracker.rows_transferred.load(Ordering::Relaxed), 10000);
     }
 }


### PR DESCRIPTION
## Summary

- Implements the previously stubbed `--progress` flag that emits JSON progress updates to stderr during migration
- Adds `ProgressTracker` struct with atomic counters for thread-safe progress tracking during concurrent table transfers
- Emits progress at each migration phase: `extracting_schema`, `schema_extracted`, `preparing_target`, `transferring`, `finalizing`
- Tracks `tables_completed`, `rows_transferred`, and `rows_per_second` with `current_table` name on completion

## Output Format

JSON lines to stderr:
```json
{"timestamp":"...","phase":"transferring","tables_completed":5,"tables_total":10,"rows_transferred":5138728,"rows_per_second":76810,"current_table":"dbo.PostLinks"}
```

## Test plan

- [x] Verified JSON progress output with `--progress` flag
- [x] All existing tests pass
- [x] Progress updates emitted at phase transitions
- [x] Table completion progress tracked correctly with accumulated row counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)