### PR TITLE
refactor: change encrypt config from string to boolean

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -11,7 +11,7 @@
     "password": "your_mssql_password",
     "schema": "dbo",
     "trust_server_cert": true,
-    "encrypt": "false"
+    "encrypt": false
   },
 
   "target": {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -16,7 +16,7 @@ source:
   schema: dbo
   # SSL/TLS settings
   trust_server_cert: true
-  encrypt: "false"
+  encrypt: false
 
 # Target database (PostgreSQL)
 target:

--- a/crates/mssql-pg-migrate/src/config/mod.rs
+++ b/crates/mssql-pg-migrate/src/config/mod.rs
@@ -65,12 +65,6 @@ impl Config {
 impl SourceConfig {
     /// Build a connection string for tiberius.
     pub fn connection_string(&self) -> String {
-        let encrypt = match self.encrypt.to_lowercase().as_str() {
-            "true" | "yes" | "1" => "true",
-            "false" | "no" | "0" | "disable" => "false",
-            _ => "true",
-        };
-
         format!(
             "Server=tcp:{},{};Database={};User Id={};Password={};Encrypt={};TrustServerCertificate={}",
             self.host,
@@ -78,7 +72,7 @@ impl SourceConfig {
             self.database,
             self.user,
             self.password,
-            encrypt,
+            self.encrypt,
             self.trust_server_cert
         )
     }
@@ -109,7 +103,7 @@ source:
   user: sa
   password: password
   schema: dbo
-  encrypt: "false"
+  encrypt: false
   trust_server_cert: true
 
 target:
@@ -136,7 +130,7 @@ migration:
     "user": "sa",
     "password": "password",
     "schema": "dbo",
-    "encrypt": "false",
+    "encrypt": false,
     "trust_server_cert": true
   },
   "target": {

--- a/crates/mssql-pg-migrate/src/config/types.rs
+++ b/crates/mssql-pg-migrate/src/config/types.rs
@@ -138,9 +138,9 @@ pub struct SourceConfig {
     #[serde(default = "default_dbo_schema")]
     pub schema: String,
 
-    /// Encrypt connection (default: "true").
-    #[serde(default = "default_true_string")]
-    pub encrypt: String,
+    /// Encrypt connection (default: true).
+    #[serde(default = "default_true")]
+    pub encrypt: bool,
 
     /// Trust server certificate (default: false).
     #[serde(default)]
@@ -589,10 +589,6 @@ fn default_dbo_schema() -> String {
 
 fn default_public_schema() -> String {
     "public".to_string()
-}
-
-fn default_true_string() -> String {
-    "true".to_string()
 }
 
 fn default_require() -> String {

--- a/crates/mssql-pg-migrate/src/config/validation.rs
+++ b/crates/mssql-pg-migrate/src/config/validation.rs
@@ -79,7 +79,7 @@ mod tests {
                 user: "sa".to_string(),
                 password: "password".to_string(),
                 schema: "dbo".to_string(),
-                encrypt: "false".to_string(),
+                encrypt: false,
                 trust_server_cert: true,
             },
             target: TargetConfig {

--- a/crates/mssql-pg-migrate/src/source/mod.rs
+++ b/crates/mssql-pg-migrate/src/source/mod.rs
@@ -70,16 +70,13 @@ impl TiberiusConnectionManager {
         ));
 
         // Encryption settings
-        match self.config.encrypt.to_lowercase().as_str() {
-            "false" | "no" | "0" | "disable" => {
-                config.encryption(EncryptionLevel::NotSupported);
+        if self.config.encrypt {
+            if self.config.trust_server_cert {
+                config.trust_cert();
             }
-            _ => {
-                if self.config.trust_server_cert {
-                    config.trust_cert();
-                }
-                config.encryption(EncryptionLevel::Required);
-            }
+            config.encryption(EncryptionLevel::Required);
+        } else {
+            config.encryption(EncryptionLevel::NotSupported);
         }
 
         config


### PR DESCRIPTION
## Summary
- Changed `encrypt` config setting from `String` to `bool` type
- Simplified connection string builder and TLS configuration logic
- Updated example config files and tests to use boolean values

## Changes
- `types.rs`: Changed field type and removed unused `default_true_string()` function
- `config/mod.rs`: Simplified connection string building
- `source/mod.rs`: Simplified TLS encryption logic from string matching to bool check
- Updated `config.example.yaml` and `config.example.json`
- Updated test fixtures in `validation.rs` and `mod.rs`

## Test plan
- [x] All 86 existing tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)