### PR TITLE
fix: address M3 Max benchmark review findings

### DIFF
--- a/crates/dmt-rs-cli/src/main.rs
+++ b/crates/dmt-rs-cli/src/main.rs
@@ -6,7 +6,7 @@ mod wizard;
 mod tui;
 
 use clap::{Parser, Subcommand};
-use dmt_rs::{Config, MigrateError, Orchestrator};
+use dmt_rs::{Config, DatabaseType, MigrateError, Orchestrator};
 use std::path::PathBuf;
 use std::process::ExitCode;
 use tokio_util::sync::CancellationToken;
@@ -310,6 +310,14 @@ async fn run() -> Result<(), MigrateError> {
         }
 
         Commands::HealthCheck => {
+            // Capture type display names before `config` is moved into Orchestrator.
+            let source_display = DatabaseType::parse(&config.source.r#type)
+                .map(|t| t.display_name())
+                .unwrap_or("Unknown");
+            let target_display = DatabaseType::parse(&config.target.r#type)
+                .map(|t| t.display_name())
+                .unwrap_or("Unknown");
+
             let orchestrator = Orchestrator::new(config).await?;
             let health_result = orchestrator.health_check().await;
             orchestrator.close().await;
@@ -320,7 +328,8 @@ async fn run() -> Result<(), MigrateError> {
             } else {
                 println!("Health Check Results:");
                 println!(
-                    "  Source (MSSQL): {} ({}ms)",
+                    "  Source ({}): {} ({}ms)",
+                    source_display,
                     if result.source_connected {
                         "OK"
                     } else {
@@ -332,7 +341,8 @@ async fn run() -> Result<(), MigrateError> {
                     println!("    Error: {}", err);
                 }
                 println!(
-                    "  Target (PostgreSQL): {} ({}ms)",
+                    "  Target ({}): {} ({}ms)",
+                    target_display,
                     if result.target_connected {
                         "OK"
                     } else {

--- a/crates/dmt-rs-cli/src/wizard.rs
+++ b/crates/dmt-rs-cli/src/wizard.rs
@@ -1,7 +1,9 @@
 //! Interactive configuration wizard for creating/editing config files.
 
 use dialoguer::{Confirm, Input, Password, Select};
-use dmt_rs::{Config, MigrationConfig, Orchestrator, SourceConfig, TargetConfig, TargetMode};
+use dmt_rs::{
+    Config, DatabaseType, MigrationConfig, Orchestrator, SourceConfig, TargetConfig, TargetMode,
+};
 use std::path::Path;
 
 /// Result type for wizard operations.
@@ -527,6 +529,13 @@ async fn test_connections(config: &Config) -> WizardResult<()> {
 
     println!("\nTesting connections...");
 
+    let source_display = DatabaseType::parse(&config.source.r#type)
+        .map(|t| t.display_name())
+        .unwrap_or("Unknown");
+    let target_display = DatabaseType::parse(&config.target.r#type)
+        .map(|t| t.display_name())
+        .unwrap_or("Unknown");
+
     // Use a 30-second timeout to prevent hanging indefinitely
     let timeout_duration = Duration::from_secs(30);
 
@@ -556,7 +565,8 @@ async fn test_connections(config: &Config) -> WizardResult<()> {
     match result {
         Ok(health) => {
             println!(
-                "  Source (MSSQL): {} ({}ms)",
+                "  Source ({}): {} ({}ms)",
+                source_display,
                 if health.source_connected {
                     "OK"
                 } else {
@@ -569,7 +579,8 @@ async fn test_connections(config: &Config) -> WizardResult<()> {
             }
 
             println!(
-                "  Target (PostgreSQL): {} ({}ms)",
+                "  Target ({}): {} ({}ms)",
+                target_display,
                 if health.target_connected {
                     "OK"
                 } else {

--- a/crates/dmt-rs/src/config/types.rs
+++ b/crates/dmt-rs/src/config/types.rs
@@ -101,6 +101,19 @@ impl DatabaseType {
             Self::Mysql => "mysql",
         }
     }
+
+    /// Get the human-readable display name for this database type.
+    ///
+    /// Used in CLI/TUI output where proper casing matters
+    /// (e.g. "MSSQL", "PostgreSQL", "MySQL"). Prefer this over
+    /// [`Self::as_str`] for anything shown to the user.
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            Self::Mssql => "MSSQL",
+            Self::Postgres => "PostgreSQL",
+            Self::Mysql => "MySQL",
+        }
+    }
 }
 
 /// System resource information for auto-tuning.

--- a/crates/dmt-rs/src/drivers/postgres/reader.rs
+++ b/crates/dmt-rs/src/drivers/postgres/reader.rs
@@ -42,8 +42,12 @@ impl PostgresReader {
             recycling_method: RecyclingMethod::Fast,
         };
 
-        let ssl_mode = config.ssl_mode.as_str();
-        let pool = match ssl_mode.to_lowercase().as_str() {
+        // Normalize once so both the outer match and build_tls_config see the
+        // same lowercased value — otherwise users setting `ssl_mode: Require`
+        // (or any mixed case) take the TLS branch here but then fail in
+        // build_tls_config's case-sensitive inner match.
+        let ssl_mode = config.ssl_mode.to_lowercase();
+        let pool = match ssl_mode.as_str() {
             "disable" => {
                 warn!("PostgreSQL TLS is disabled. Credentials will be transmitted in plaintext.");
                 let mgr = Manager::from_config(pg_config, tokio_postgres::NoTls, mgr_config);
@@ -53,7 +57,7 @@ impl PostgresReader {
                     .map_err(|e| MigrateError::pool(e, "creating PostgreSQL source pool"))?
             }
             _ => {
-                let tls_config = Self::build_tls_config(ssl_mode)?;
+                let tls_config = Self::build_tls_config(&ssl_mode)?;
                 let tls_connector = MakeRustlsConnect::new(tls_config);
                 let mgr = Manager::from_config(pg_config, tls_connector, mgr_config);
                 Pool::builder(mgr)

--- a/crates/dmt-rs/src/drivers/postgres/reader.rs
+++ b/crates/dmt-rs/src/drivers/postgres/reader.rs
@@ -42,7 +42,7 @@ impl PostgresReader {
             recycling_method: RecyclingMethod::Fast,
         };
 
-        let ssl_mode = "require";
+        let ssl_mode = config.ssl_mode.as_str();
         let pool = match ssl_mode.to_lowercase().as_str() {
             "disable" => {
                 warn!("PostgreSQL TLS is disabled. Credentials will be transmitted in plaintext.");

--- a/crates/dmt-rs/src/drivers/postgres/writer.rs
+++ b/crates/dmt-rs/src/drivers/postgres/writer.rs
@@ -53,8 +53,12 @@ impl PostgresWriter {
             recycling_method: RecyclingMethod::Fast,
         };
 
-        let ssl_mode = config.ssl_mode.as_str();
-        let pool = match ssl_mode.to_lowercase().as_str() {
+        // Normalize once so both the outer match and build_tls_config see the
+        // same lowercased value — otherwise users setting `ssl_mode: Require`
+        // (or any mixed case) take the TLS branch here but then fail in
+        // build_tls_config's case-sensitive inner match.
+        let ssl_mode = config.ssl_mode.to_lowercase();
+        let pool = match ssl_mode.as_str() {
             "disable" => {
                 warn!("PostgreSQL TLS is disabled. Credentials will be transmitted in plaintext.");
                 let mgr = Manager::from_config(pg_config, tokio_postgres::NoTls, mgr_config);
@@ -64,7 +68,7 @@ impl PostgresWriter {
                     .map_err(|e| MigrateError::pool(e, "creating PostgreSQL target pool"))?
             }
             _ => {
-                let tls_config = Self::build_tls_config(ssl_mode)?;
+                let tls_config = Self::build_tls_config(&ssl_mode)?;
                 let tls_connector = MakeRustlsConnect::new(tls_config);
                 let mgr = Manager::from_config(pg_config, tls_connector, mgr_config);
                 Pool::builder(mgr)

--- a/crates/dmt-rs/src/state/schema.sql
+++ b/crates/dmt-rs/src/state/schema.sql
@@ -1,46 +1,50 @@
 -- Migration state schema for dmt-rs
--- Stores migration run history and per-table state for resume and incremental sync
+--
+-- NOTE: this file is documentation only — the live schema is created
+-- programmatically by `DbStateBackend::init_schema` in `db.rs` (and the
+-- MSSQL/MySQL equivalents in the sibling modules). Keep it in sync with
+-- the code if either side changes; do NOT include this file at build
+-- time via `include_str!`.
+--
+-- The schema has a single denormalized table `_dmt_rs.table_state` that
+-- stores all run-level metadata alongside each per-table row. There is
+-- NO separate `migration_runs` table, even though an earlier version of
+-- this file (and `docs/tech-specs.md`) described one. See §7 of
+-- `docs/benchmark-playbook.md` for the canonical validation query.
 
--- Migration runs (overall state)
-CREATE TABLE IF NOT EXISTS _dmt_rs.migration_runs (
-    run_id TEXT PRIMARY KEY,
-    config_hash TEXT NOT NULL,
-    started_at TIMESTAMPTZ NOT NULL,
-    completed_at TIMESTAMPTZ,
-    status TEXT NOT NULL CHECK (status IN ('running', 'completed', 'failed', 'cancelled')),
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
-
--- Per-table state for each migration run
+-- Per-table state (denormalized with run-level fields)
 CREATE TABLE IF NOT EXISTS _dmt_rs.table_state (
-    run_id TEXT NOT NULL REFERENCES _dmt_rs.migration_runs(run_id) ON DELETE CASCADE,
-    table_name TEXT NOT NULL,
-    status TEXT NOT NULL CHECK (status IN ('pending', 'in_progress', 'completed', 'failed')),
-    rows_total BIGINT NOT NULL DEFAULT 0,
-    rows_transferred BIGINT NOT NULL DEFAULT 0,
-    rows_skipped BIGINT NOT NULL DEFAULT 0,
-    last_pk BIGINT,
+    run_id             TEXT        NOT NULL,
+    config_hash        TEXT        NOT NULL,
+    run_started_at     TIMESTAMPTZ NOT NULL,
+    run_completed_at   TIMESTAMPTZ,
+    run_status         TEXT        NOT NULL
+                       CHECK (run_status IN ('running', 'completed', 'failed', 'cancelled')),
+    table_name         TEXT        NOT NULL,
+    table_status       TEXT        NOT NULL
+                       CHECK (table_status IN ('pending', 'in_progress', 'completed', 'failed')),
+    rows_total          BIGINT     NOT NULL DEFAULT 0,
+    rows_transferred    BIGINT     NOT NULL DEFAULT 0,
+    rows_skipped        BIGINT     NOT NULL DEFAULT 0,
+    last_pk             BIGINT,
     last_sync_timestamp TIMESTAMPTZ,  -- For date-based incremental sync
-    completed_at TIMESTAMPTZ,
-    error TEXT,
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    table_completed_at  TIMESTAMPTZ,
+    error               TEXT,
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (run_id, table_name)
 );
 
--- Index for finding latest successful sync per table (for incremental sync)
+-- Index for incremental-sync watermark lookups
 CREATE INDEX IF NOT EXISTS idx_table_state_incremental_sync
-    ON _dmt_rs.table_state(table_name, status, last_sync_timestamp)
-    WHERE status = 'completed' AND last_sync_timestamp IS NOT NULL;
+    ON _dmt_rs.table_state(table_name, table_status, last_sync_timestamp)
+    WHERE table_status = 'completed' AND last_sync_timestamp IS NOT NULL;
 
--- Index for finding latest run
-CREATE INDEX IF NOT EXISTS idx_migration_runs_latest
-    ON _dmt_rs.migration_runs(started_at DESC);
-
-COMMENT ON TABLE _dmt_rs.migration_runs IS
-    'Migration run history for dmt-rs. Each row represents one migration run.';
+-- Index for latest-run lookups (by config hash, run start time descending)
+CREATE INDEX IF NOT EXISTS idx_table_state_latest_run
+    ON _dmt_rs.table_state(config_hash, run_started_at DESC);
 
 COMMENT ON TABLE _dmt_rs.table_state IS
-    'Per-table state for each migration run. Used for crash recovery and incremental sync.';
+    'Per-table migration state for dmt-rs, denormalized with run-level fields. Used for resume and date-based incremental sync.';
 
 COMMENT ON COLUMN _dmt_rs.table_state.last_sync_timestamp IS
-    'High-water mark timestamp for date-based incremental sync. Set to run start time after successful completion.';
+    'High-water mark for date-based incremental sync. Set to the run start time after successful completion, so the next run only fetches rows newer than this.';

--- a/docs/benchmark-playbook.md
+++ b/docs/benchmark-playbook.md
@@ -21,7 +21,7 @@ for the actual cross-hardware results.
 > buffer pool effect); MSSQL targets are buffer-pool-bound (dirty pages
 > absorb in RAM, checkpoint amortizes over slow storage). NVMe bandwidth
 > matters roughly as much as RAM size — **not negligible** as this doc
-> originally claimed. See §3 below for the corrected model.
+> originally claimed. See §2 below for the corrected model.
 
 ---
 

--- a/docs/benchmark-playbook.md
+++ b/docs/benchmark-playbook.md
@@ -4,15 +4,24 @@ A reproducible, self-contained procedure for running the dmt-rs end-to-end
 benchmark across all four `{mssql,pg} × {mssql,pg}` migration directions,
 plus the infrastructure gotchas and cross-hardware prediction table.
 
-Authoring context: this doc was written at the end of a session on an
-**M5 Pro 24 GB** (MacBook) running Docker Desktop with x86_64 emulation for
-MSSQL, targeting a follow-up session on an **M3 Max 36 GB** that will
-validate the predictions in the last table.
+Authoring context: this doc was first written at the end of a session on
+an **M5 Pro 24 GB** (MacBook) running Docker Desktop with x86_64 emulation
+for MSSQL, then revised after a follow-up run on **M3 Max 36 GB** refuted
+the original §2 hypothesis. See [`benchmark-results-m3-max.md`](benchmark-results-m3-max.md)
+for the actual cross-hardware results.
 
 > **Note on scope.** This playbook documents a benchmark harness against
 > real databases, not the unit test suite. `cargo test --all-features`
 > needs nothing beyond a working Rust toolchain. The procedures below
 > are for measuring end-to-end migration throughput on real data.
+
+> **Most important finding from cross-hardware validation**: the dominant
+> factor is **the target database type, not the host chip**. PG targets
+> are storage-bound (COPY flushes dirty pages direct to disk, no meaningful
+> buffer pool effect); MSSQL targets are buffer-pool-bound (dirty pages
+> absorb in RAM, checkpoint amortizes over slow storage). NVMe bandwidth
+> matters roughly as much as RAM size — **not negligible** as this doc
+> originally claimed. See §3 below for the corrected model.
 
 ---
 
@@ -58,40 +67,44 @@ transfer in 3–18 seconds regardless of direction.
 
 ---
 
-## 2. Hardware comparison and M3 Max predictions
+## 2. Hardware comparison
 
-The dmt-rs benchmark workload on Apple Silicon is **memory-bound in the
-Docker VM**, not CPU-bound. MSSQL has no ARM Linux build, so it's always
-running under Rosetta 2 — neither chip can avoid the 2-5× emulation
-penalty. Postgres containers run native ARM (`postgres:16-alpine` has an
-arm64 manifest), so they're not affected by chip choice.
+MSSQL has no ARM Linux build, so it's always running under Rosetta 2
+regardless of chip — neither M5 Pro nor M3 Max can avoid the 2-5×
+emulation penalty. Postgres containers run native ARM64
+(`postgres:16-alpine` has an arm64 manifest), so they're not affected
+by chip choice itself.
 
-| Factor | M5 Pro 24 GB | M3 Max 36 GB | Impact |
+| Factor | M5 Pro 24 GB | M3 Max 36 GB | Impact on this workload |
 |---|---|---|---|
 | Per-core perf | Higher (newer P-cores) | Lower (~5-15%) | Negligible — workload isn't CPU-bound |
 | Core count | 10-12 | 14-16 | Negligible — we `--cpus=4` cap containers |
-| **Available RAM for Docker VM** | **~7.75 GiB** (24 - macOS - apps) | **~20-24 GiB** | **Dominant factor** |
+| **Available RAM for Docker VM** | **~7.75 GiB** (24 - macOS - apps) | **~20-24 GiB** | **Helps MSSQL-target directions (big buffer pool). Minimal impact on PG-target directions.** |
 | Rosetta 2 generation | Latest | 2 generations older | Marginal (~5-10% slower emulation) |
-| NVMe bandwidth | Slightly faster | Slightly slower | Negligible once working set fits in RAM |
+| **NVMe bandwidth** | **Faster** | **~50% slower** (!) | **Dominates PG-target directions and PG→PG.** This was the surprise from the M3 Max run. |
 
-### Predictions for M3 Max 36 GB with Docker Desktop set to 20 GiB
+### The corrected workload model
 
-| Direction | M5 Pro 24 GB | **M3 Max 36 GB predicted** | Main reason |
-|---|---:|---:|---|
-| pg → pg | 16.5s | **~14-16s** | PG is already fast; small Rosetta regression offsets bigger cache |
-| mssql → pg | 43.3s | **~22-28s** | MSSQL source gets 6-8 GiB buffer pool → SO2010 buffer-pool cached → Posts read goes from disk-bound to memory-speed |
-| pg → mssql | 104.8s | **~80-90s** | Target-side dirty page buffer grows; still bottlenecked by tiberius LOB INSERT path |
-| mssql → mssql | 98.6s | **~60-70s** | Both sides can run full-fat without bb8 pool contention |
-| **Catastrophic failure risk** | **Real** (we hit it twice) | **Low** | Whole class of VM-OOM failures goes away |
+> **The dominant factor is the target database type, not the host chip:**
+>
+> - **PG targets** are storage-bound. `COPY` flushes dirty pages direct to
+>   disk; `shared_buffers` helps source reads a little but doesn't mask
+>   target-side writes. Slower NVMe → slower migration, end of story.
+> - **MSSQL targets** are buffer-pool-bound. Dirty pages absorb in RAM and
+>   the dirty page flusher amortizes against slow storage. More RAM → big
+>   win even on slower NVMe.
+> - **Source reads on MSSQL** benefit from the buffer pool once the data
+>   file is warm (the SO2010 `.mdf` is ~9 GB; on a 6 GB `max server memory`
+>   cap, most of Posts' LOB pages fit after warm-up).
+> - **Source reads on PG** pay storage cost on every chunk because PG's
+>   COPY path doesn't warm `shared_buffers` aggressively for sequential
+>   scans.
 
-### Predictions *not* expected to improve materially
-
-- **Posts throughput on pg→mssql** — the ceiling is the tiberius batched
-  INSERT path's LOB handling, not memory or CPU. The `mssql-client` spike
-  from earlier this session identified this as the fundamental limitation.
-  See `docs/mssql-client-spike.md`.
-- **Individual small-table throughput** — the lookup tables (PostTypes,
-  VoteTypes, LinkTypes) are dominated by per-query overhead, not scaling.
+This model predicts every row of the M3 Max results correctly (see
+[`benchmark-results-m3-max.md`](benchmark-results-m3-max.md) §3). The
+*original* §2 of this playbook said "NVMe bandwidth: negligible once
+working set fits in RAM" — that was wrong for PG-target directions
+specifically.
 
 ---
 
@@ -472,7 +485,13 @@ container (port 1434), not `mssql-source`.
 ## 7. Validation
 
 Every successful run writes state to the `_dmt_rs` schema in the target
-database. Verify row integrity:
+database. The schema has **one denormalized table** (`_dmt_rs.table_state`)
+with all run-level fields (`run_id`, `run_started_at`, `run_completed_at`,
+`run_status`, `config_hash`) stored alongside each per-table row — there is
+no separate `migration_runs` table, despite what an earlier version of
+this doc and `docs/tech-specs.md` originally claimed.
+
+Verify row integrity after a run:
 
 ```bash
 # For PostgreSQL targets
@@ -480,9 +499,9 @@ docker exec pg-target psql -U postgres -d dmt_test_target -c "
 SELECT table_name, rows_total, rows_transferred, table_status,
        EXTRACT(EPOCH FROM (table_completed_at - run_started_at))::numeric(10,2) AS t_plus_sec
 FROM _dmt_rs.table_state
-WHERE run_id = (SELECT run_id FROM _dmt_rs.migration_runs
-                WHERE status = 'completed'
-                ORDER BY started_at DESC LIMIT 1)
+WHERE run_id = (SELECT run_id FROM _dmt_rs.table_state
+                WHERE run_status = 'completed'
+                ORDER BY run_started_at DESC LIMIT 1)
 ORDER BY table_completed_at;
 "
 
@@ -491,8 +510,8 @@ docker exec mssql-target /opt/mssql-tools18/bin/sqlcmd \
   -S localhost -U sa -P 'YourStrong@Passw0rd' -C -d dmt_test_target -Q "
 SELECT table_name, rows_total, rows_transferred, table_status
 FROM _dmt_rs.table_state
-WHERE run_id = (SELECT TOP 1 run_id FROM _dmt_rs.migration_runs
-                WHERE status = 'completed' ORDER BY started_at DESC)
+WHERE run_id = (SELECT TOP 1 run_id FROM _dmt_rs.table_state
+                WHERE run_status = 'completed' ORDER BY run_started_at DESC)
 ORDER BY table_completed_at;
 "
 ```
@@ -592,77 +611,179 @@ conclude a tuning change worked or didn't work from a single run.
 The M3 Max should behave similarly — emulation variance is inherent
 to Rosetta 2 and not chip-gen-specific.
 
+### 8.7 Apple Silicon NVMe bandwidth varies significantly between machines
+
+Don't assume cross-Mac storage parity. The M3 Max in the cross-hardware
+run had NVMe roughly half the speed of the M5 Pro, which moved benchmark
+numbers by 30-60% in the PG-target directions (and was the root cause of
+the original §9 predictions being wrong — see §2). If you're comparing
+results across machines, either measure NVMe bandwidth first or treat
+unexplained regressions as storage-limited until proven otherwise.
+
+### 8.8 Pre-existing Azure SQL Edge volumes are risky to mount into SQL Server 2022
+
+If the host already has an `mssql-bench-data` volume from a prior Azure
+SQL Edge session (the native arm64 image, internal version ~921,
+vintage SQL Server 2017), **do not mount it directly into a
+`mcr.microsoft.com/mssql/server:2022-latest` container**. SQL Server 2022
+will attempt an in-place upgrade of the system databases on first start,
+which can fail with cryptic errors on Edge-specific metadata.
+
+Safe procedure for reusing the data from such a volume:
+
+1. Create a fresh `mssql-source-data` volume and start SQL Server 2022
+   against it, letting it initialize clean system databases.
+2. Run a throwaway Alpine container with the old volume mounted
+   read-only at `/src` and the new volume mounted read-write at `/dst`.
+3. Copy **only** `StackOverflow2010.mdf` and `StackOverflow2010_log.ldf`
+   (not any system DB files), `chown 10001:10001`, `chmod 660`.
+4. Inside the SQL Server 2022 container, run
+   `CREATE DATABASE StackOverflow2010 ... FOR ATTACH`. The version upgrade
+   from 921 → 957 runs incrementally and succeeds in ~5 seconds.
+
+The original Azure SQL Edge volume is never modified and remains as a
+backup. Detailed procedure: see [`benchmark-results-m3-max.md`](benchmark-results-m3-max.md) §5.1.
+
+### 8.9 Phase 4 PK creation is instantaneous on MSSQL targets (not a bug)
+
+When the target is MSSQL, Phase 4 logs lines like:
+
+```
+Created PK on dbo.Votes (10143364 rows) in 0.00s
+Created PK on dbo.Posts (3729195 rows) in 0.01s
+```
+
+These are not real PK creation times. The MSSQL target dialect creates
+primary keys inline as part of `CREATE TABLE`, so the Phase 4 post-load
+step is a no-op for MSSQL. The PK cost is already baked into the
+per-table transfer times reported earlier in the run.
+
+PG targets behave differently: PG's COPY path bypasses constraints, so
+PK creation runs as a real post-load index build in Phase 4 (several
+seconds for Posts/Votes/Comments).
+
+**Consequence for analysis:** `transfer-only vs e2e` duration splits are
+**not directly comparable across target types**. When comparing MSSQL
+and PG targets, compare e2e durations, not transfer-only.
+
 ---
 
-## 9. Predictions to validate on M3 Max 36 GB
+## 9. Cross-hardware results (M5 Pro 24 GB vs M3 Max 36 GB)
 
-Running the procedure above on an M3 Max 36 GB with Docker Desktop at
-20+ GiB should produce results in the following ranges. Log the actual
-numbers and compare.
+A first pass at this section contained predictions that were wrong in
+several directions (not just magnitude — the *sign* of the pg→pg delta
+was backwards). The actual measured numbers from both hosts live here
+as a reference, plus the corrected model that explains them.
 
-| Direction | M5 Pro 24 GB (actual) | **M3 Max 36 GB (predicted)** | Win source |
+Full M3 Max details including per-table timings, cold vs warm runs,
+and new gotchas: [`benchmark-results-m3-max.md`](benchmark-results-m3-max.md).
+
+### Actual results (warm runs, 2026-04-11)
+
+| Direction | M5 Pro 24 GB | M3 Max 36 GB | Delta | Throughput (M3 Max) |
+|---|---:|---:|---:|---:|
+| pg → pg | 16.5s | **25.6s** | **+55% slower** | 755K r/s |
+| mssql → pg | 43.3s | **42.9s** | ~equal | 450K r/s |
+| pg → mssql | 104.8s | **63.8s** | **-39% faster** | 302K r/s |
+| mssql → mssql | 98.6s | **36.4s** | **-63% faster** | 530K r/s |
+| **Total wall time** | **263.2s** | **168.7s** | **-36% overall** | |
+| Catastrophic failure risk | Real (hit 2x) | Low (no failures observed) | | |
+
+The M3 Max wins the overall cross-section by 36%, but **only two of four
+directions actually improved**. PG-target directions regressed because of
+slower NVMe; MSSQL-target directions won big because of larger MSSQL
+buffer pools. This is the corrected model from §2 applied to real data.
+
+### What changed vs the original §9 predictions
+
+The original predictions assumed the workload was "memory-bound in the
+Docker VM" and that more RAM would help every direction. That was wrong:
+
+| Direction | Original prediction | Actual | Why prediction was wrong |
 |---|---:|---:|---|
-| pg → pg | 16.5s (1,168K r/s) | **14-16s (1,200K-1,400K r/s)** | Minor — workload already fast |
-| mssql → pg | 43.3s (445K r/s) | **22-28s (~700K-880K r/s)** | **Big** — MSSQL buffer pool holds Posts |
-| pg → mssql | 104.8-162s (120-185K r/s) | **80-90s (215-240K r/s)** | Modest — tiberius LOB INSERT is still the ceiling |
-| mssql → mssql | 98.6s (196K r/s) | **60-70s (275-320K r/s)** | **Big** — no bb8 contention, fat buffer pools |
-| Catastrophic failure risk | Real (hit twice) | Low | Memory headroom eliminates the failure mode |
+| pg → pg | 14-16s | 25.6s | PG-target is storage-bound, not memory-bound. Slower NVMe on M3 Max dominates; larger RAM doesn't help. |
+| mssql → pg | 22-28s | 42.9s | MSSQL buffer pool wins on the read side but PG target-side writes still hit disk. Wash. |
+| pg → mssql | 80-90s | 63.8s | MSSQL target buffer pool is *more* impactful than predicted — dirty pages absorb in RAM so aggressively that the tiberius LOB INSERT path was never the real ceiling. |
+| mssql → mssql | 60-70s | 36.4s | Both sides benefit from the bigger buffer pools simultaneously; the win compounds. |
 
-Per-table prediction for `mssql → pg` specifically, since that's the most
-informative direction:
+Error pattern: predictions assumed RAM helped source-read and target-write
+equally, but in practice **extra RAM only helps target-write meaningfully
+on MSSQL** (because of the checkpoint-based flush model). PG's COPY path
+bypasses `shared_buffers` aggressively enough that a bigger cache doesn't
+speed up the target side — only the source side, and the gain is small.
 
-| Table | M5 Pro 24 GB | **M3 Max 36 GB predicted** |
-|---|---:|---:|
-| Posts (dominant) | 26.67s (47K r/s per partition) | **~15s (~85K r/s per partition)** |
-| Votes (3 partitions) | 3.24s (1.04M r/s per partition) | **~2s (1.7M r/s per partition)** |
-| Comments (3 partitions) | 5.01s (258K r/s per partition) | **~3s (430K r/s per partition)** |
-| Badges, Users, PostLinks | <1s each | ~same |
+### Per-table detail: `mssql → pg`
 
-### If the predictions are wrong
+| Table | M5 Pro (actual) | M3 Max (actual) | Δ |
+|---|---:|---:|---:|
+| Posts (dominant) | 26.67s | 34.3s | **+28% slower** (slower NVMe on target write hurts) |
+| Comments | 5.01s | 16.4s | **+227% slower** (same reason, scaled by row count) |
+| Votes (3 partitions) | 3.24s | ~4.5s | slower |
+| Badges, Users, PostLinks | <1s each | <1s each | ~equal |
 
-- **Posts speedup smaller than expected**: probably means the MSSQL buffer
-  pool isn't actually caching the LOB pages. Check `max server memory`
-  actually took effect (`SELECT value_in_use FROM sys.configurations
-  WHERE name = 'max server memory (MB)'`) and that the container can grow
-  into its Docker cap. Also verify SO2010's `.mdf` is being read from the
-  mounted volume, not copied into a slower container layer.
-- **pg → mssql regression**: would be surprising. If it happens, it's
-  likely a new tiberius behavior that should be investigated with the
-  `mssql-client` BCP path from the earlier spike (`docs/mssql-client-spike.md`).
-- **mssql → mssql still fails**: Docker Desktop VM size might be lower
-  than you think. Verify with `docker info | grep Memory`. Should be
-  20+ GiB for the budget in section 4.6 to work.
+Posts is still the wall-clock bottleneck on both hosts, but the distribution
+of time inside it shifted: on the M3 Max the read side is actually *faster*
+(MSSQL buffer pool) while the write side is slower (PG target NVMe). On
+the M5 Pro it was the opposite — read was slow (MSSQL hitting disk) and
+write was OK.
+
+### If you're testing on a different host
+
+Use the §2 model to predict before running:
+
+1. **Is the target MSSQL?** You'll benefit from more RAM proportionally to
+   how much of the `max server memory` you can actually give it.
+2. **Is the target PG?** Storage bandwidth matters more than RAM. A newer
+   machine with faster NVMe and less RAM will likely beat an older machine
+   with more RAM but slower storage.
+3. **Is the source MSSQL and the target PG?** Mixed case — depends on
+   which side is heavier. Posts LOB tables shift the bottleneck to the
+   target-write side.
+4. **Emulation overhead** is roughly constant across Apple Silicon
+   generations (Rosetta 2 is mature). Don't expect chip-generation
+   speedups to be large even on MSSQL-heavy directions.
 
 ---
 
-## 10. Reporting results
+## 10. Reporting results from new hosts
 
-When running on the M3 Max, capture:
+If you're running this playbook on a host not already represented in §9,
+capture:
 
-1. The full log file for each direction (at minimum `tail -30` per run).
-2. The per-table state table from section 7.
-3. A summary table comparing actual M3 Max numbers vs the predictions in
-   section 9.
-4. Any gotchas encountered that aren't in section 8 — especially new
-   failure modes unique to the larger VM.
+1. **Per-direction warm numbers** — end-to-end duration and rows/sec for
+   each of the four directions (pg→pg, mssql→pg, pg→mssql, mssql→mssql).
+   Report the *second* (warm) run of each; note cold numbers separately
+   if they differ materially.
+2. **Per-table timings** — at minimum the per-direction `transferred X
+   rows in Y` log lines for the dominant tables (Posts, Comments, Votes).
+   Grep pattern: `grep -a -E "transferred [0-9]+ rows|partitioning into|Phase 4|Migration completed"`.
+3. **State schema validation** — the §7 query against `_dmt_rs.table_state`
+   confirming every table shows `rows_transferred = rows_total` and
+   `table_status = 'completed'`.
+4. **Host profile** — chip, RAM, Docker Desktop VM memory setting, and a
+   rough NVMe bandwidth number if you can measure it (`dd if=...
+   of=/dev/null bs=1M count=1024` is a crude but useful proxy).
+5. **New gotchas** — anything not in §8. Especially new failure modes or
+   container orchestration tricks needed for the environment.
 
-Suggested output location: `docs/benchmark-results-m3-max.md` in a new
-branch (`bench/m3-max-results`), or appended as a section to this
-playbook under "Cross-hardware results". Either way, commit + push so
-future sessions can see the validated numbers.
+Output location: `docs/benchmark-results-<hostname>.md` (following the
+existing `benchmark-results-m3-max.md` pattern), committed to `main`
+alongside a one-row update to §9's cross-hardware results table in this
+file so the summary stays coherent.
 
-If any of the predictions in section 9 are wrong by more than 30%,
-investigate before declaring the result — variance alone rarely accounts
-for that much on the same workload.
+If any reading differs from the §2 target-write-pattern model's
+prediction by more than 30%, investigate before declaring the result —
+that's where the interesting findings live.
 
 ---
 
 ## Related docs
 
-- `docs/tech-specs.md` — supported versions, config schema, exit codes
-- `docs/design.md` — architecture, transfer engine, plugin pattern
-- `docs/philosophy.md` — why the tool exists, what it is NOT
-- `docs/mssql-client-spike.md` — the `mssql-client` alternative driver spike (the real fix for the pg→mssql LOB ceiling)
-- `PERFORMANCE.md` — historical benchmark data from native Linux runs (sub-second counts, 162K-300K+ rows/sec ranges)
-- `BENCHMARKS.md` — Rust vs Go comparison benchmarks
-- `run-all-tests.sh` — the 18-permutation integration test matrix
+- [`benchmark-results-m3-max.md`](benchmark-results-m3-max.md) — actual M3 Max 36 GB results + the corrected target-write-pattern model
+- [`tech-specs.md`](tech-specs.md) — supported versions, config schema, exit codes
+- [`design.md`](design.md) — architecture, transfer engine, plugin pattern
+- [`philosophy.md`](philosophy.md) — why the tool exists, what it is NOT
+- [`mssql-client-spike.md`](mssql-client-spike.md) — the `mssql-client` alternative driver spike
+- `../PERFORMANCE.md` — historical benchmark data from native Linux runs (sub-second counts, 162K-300K+ rows/sec ranges)
+- `../BENCHMARKS.md` — Rust vs Go comparison benchmarks
+- `../run-all-tests.sh` — the 18-permutation integration test matrix

--- a/docs/benchmark-playbook.md
+++ b/docs/benchmark-playbook.md
@@ -83,28 +83,56 @@ by chip choice itself.
 | Rosetta 2 generation | Latest | 2 generations older | Marginal (~5-10% slower emulation) |
 | **NVMe bandwidth** | **Faster** | **~50% slower** (!) | **Dominates PG-target directions and PG→PG.** This was the surprise from the M3 Max run. |
 
-### The corrected workload model
+### The corrected workload model (threshold-gated, feed-rate-aware)
 
-> **The dominant factor is the target database type, not the host chip:**
+> **The dominant factor is the target database type, but the MSSQL-target
+> win is threshold-gated and depends on source feed rate:**
 >
-> - **PG targets** are storage-bound. `COPY` flushes dirty pages direct to
->   disk; `shared_buffers` helps source reads a little but doesn't mask
->   target-side writes. Slower NVMe → slower migration, end of story.
-> - **MSSQL targets** are buffer-pool-bound. Dirty pages absorb in RAM and
->   the dirty page flusher amortizes against slow storage. More RAM → big
->   win even on slower NVMe.
+> - **PG targets** are storage-bound. `COPY` flushes dirty pages direct
+>   to disk; `shared_buffers` helps source reads a little but doesn't
+>   mask target-side writes. Slower NVMe → slower migration, regardless
+>   of RAM. *Confirmed on M3 Max — PG→PG regressed 55% and mssql→pg was
+>   flat despite 3× more VM memory.*
+>
+> - **MSSQL targets** are buffer-pool-bound, **but only above a threshold
+>   that scales with working-set size and source feed rate**:
+>   - **Slow source** (MSSQL → MSSQL via Rosetta): 4 GiB `max server
+>     memory` is enough. The source's own emulation overhead paces dirty
+>     page production; 4 GiB buffer pool can absorb it.
+>   - **Fast source** (PG COPY → MSSQL): need **≥6 GiB** `max server
+>     memory`. PG's COPY fires rows faster than the 4 GiB buffer pool
+>     can absorb, causing spillover to disk. 6 GiB crosses the threshold
+>     for SO2010's ~6 GB of Posts.Body LOB content — the whole working
+>     set fits and dirty pages absorb in memory.
+>   - The threshold **is not constant** — it depends on how much LOB
+>     content the workload has. For smaller datasets with narrow rows,
+>     4 GiB may be sufficient even for PG → MSSQL.
+>
 > - **Source reads on MSSQL** benefit from the buffer pool once the data
->   file is warm (the SO2010 `.mdf` is ~9 GB; on a 6 GB `max server memory`
->   cap, most of Posts' LOB pages fit after warm-up).
+>   file is warm (the SO2010 `.mdf` is ~9 GB; on a 6 GB `max server
+>   memory` cap, most of Posts' LOB pages fit after warm-up).
+>
 > - **Source reads on PG** pay storage cost on every chunk because PG's
 >   COPY path doesn't warm `shared_buffers` aggressively for sequential
 >   scans.
 
-This model predicts every row of the M3 Max results correctly (see
-[`benchmark-results-m3-max.md`](benchmark-results-m3-max.md) §3). The
-*original* §2 of this playbook said "NVMe bandwidth: negligible once
-working set fits in RAM" — that was wrong for PG-target directions
-specifically.
+This model was refined through three experiments:
+
+1. **Original M5 Pro run** (8 GiB Docker VM, 3 GiB max server memory) —
+   baseline.
+2. **M3 Max run** (23 GiB Docker VM, 6 GiB max server memory) — refuted
+   the original "memory-bound, NVMe negligible" hypothesis. Same chip
+   generation and OS, but NVMe differences moved pg→pg and mssql→pg.
+3. **M5 Pro bumped run** (12 GiB Docker VM, 4 GiB max server memory,
+   then 6 GiB) — isolated the single variable of target `max server
+   memory`. pg→mssql stayed at 107s with 4 GiB and dropped to 79s with
+   6 GiB — nothing else changed. This is what established the threshold
+   model.
+
+The *original* §2 of this playbook said "NVMe bandwidth: negligible once
+working set fits in RAM" — wrong for PG targets. It also said "more RAM
+→ big win for all MSSQL-target directions" — wrong for `pg → mssql` at
+the 4 GiB level. Both statements are now corrected above.
 
 ---
 
@@ -668,49 +696,78 @@ and PG targets, compare e2e durations, not transfer-only.
 
 ---
 
-## 9. Cross-hardware results (M5 Pro 24 GB vs M3 Max 36 GB)
+## 9. Cross-hardware and cross-memory results
 
-A first pass at this section contained predictions that were wrong in
-several directions (not just magnitude — the *sign* of the pg→pg delta
-was backwards). The actual measured numbers from both hosts live here
-as a reference, plus the corrected model that explains them.
+This section has been refined through three experiments and four data
+points. The original predictions (not shown here — see the git history
+of this file) were wrong in ways that revealed a **feed-rate-aware,
+threshold-gated** version of the target-write-pattern model. See §2
+for the current model.
 
-Full M3 Max details including per-table timings, cold vs warm runs,
-and new gotchas: [`benchmark-results-m3-max.md`](benchmark-results-m3-max.md).
+Full M3 Max details including per-table timings and new gotchas:
+[`benchmark-results-m3-max.md`](benchmark-results-m3-max.md).
 
-### Actual results (warm runs, 2026-04-11)
+### Four-point dataset (warm runs, 2026-04-11)
 
-| Direction | M5 Pro 24 GB | M3 Max 36 GB | Delta | Throughput (M3 Max) |
+Variables: host (M5 Pro 24 GB vs M3 Max 36 GB), Docker VM size, target
+MSSQL `max server memory`. Everything else held constant (same binary,
+same data, same workload).
+
+| Config | Host | Docker VM | Max server mem | pg→pg | mssql→pg | pg→mssql | mssql→mssql | Total |
+|---|---|---:|---:|---:|---:|---:|---:|---:|
+| **A** | M5 Pro | 7.75 GiB | 3 GiB | 16.5s | 43.3s | 104.8s | 98.6s | **263.2s** |
+| **B** | M5 Pro | 11.67 GiB | 4 GiB | 18.0s | 44.6s | 107.8s | 64.4s | **234.8s** |
+| **C** | M5 Pro | 11.67 GiB | 6 GiB* | — | — | **78.8s** | — | partial run |
+| **D** | M3 Max | 23.43 GiB | 6 GiB | 25.6s | 42.9s | 63.8s | 36.4s | **168.7s** |
+
+\* Config C isolated `pg → mssql` only to test the threshold theory (see
+below). Other directions not re-run because they're not the threshold
+case.
+
+Throughput (warm, end-to-end, rows/sec):
+
+| Config | pg→pg | mssql→pg | pg→mssql | mssql→mssql |
 |---|---:|---:|---:|---:|
-| pg → pg | 16.5s | **25.6s** | **+55% slower** | 755K r/s |
-| mssql → pg | 43.3s | **42.9s** | ~equal | 450K r/s |
-| pg → mssql | 104.8s | **63.8s** | **-39% faster** | 302K r/s |
-| mssql → mssql | 98.6s | **36.4s** | **-63% faster** | 530K r/s |
-| **Total wall time** | **263.2s** | **168.7s** | **-36% overall** | |
-| Catastrophic failure risk | Real (hit 2x) | Low (no failures observed) | | |
+| **A** (M5 Pro / 3 GiB) | 1,168K | 445K | 184K | 196K |
+| **B** (M5 Pro / 4 GiB) | 1,074K | 433K | 179K | 300K |
+| **C** (M5 Pro / 6 GiB) | — | — | **245K** | — |
+| **D** (M3 Max / 6 GiB) | 755K | 450K | 302K | 530K |
 
-The M3 Max wins the overall cross-section by 36%, but **only two of four
-directions actually improved**. PG-target directions regressed because of
-slower NVMe; MSSQL-target directions won big because of larger MSSQL
-buffer pools. This is the corrected model from §2 applied to real data.
+### Key findings
 
-### What changed vs the original §9 predictions
+**1. `mssql → mssql` scales with target buffer pool even at 4 GiB.**
+B → A shows a 35% improvement (98.6s → 64.4s) from bumping `max server
+memory` from 3 GiB to 4 GiB. D shows another 43% improvement on top of
+that at 6 GiB. The direction responds smoothly to more RAM because the
+source feed rate is throttled by its own Rosetta emulation cost — the
+target doesn't get overwhelmed.
 
-The original predictions assumed the workload was "memory-bound in the
-Docker VM" and that more RAM would help every direction. That was wrong:
+**2. `pg → mssql` has a hard threshold between 4 and 6 GiB.** At
+3 GiB (A): 104.8s. At 4 GiB (B): 107.8s — no improvement. **At 6 GiB
+(C): 78.8s — 26% improvement from a single 2 GiB step.** This is the
+PG COPY source saturating the target INSERT path. Below the threshold,
+dirty pages spill to disk and the migration is I/O-bound; above it,
+they stay in memory and the migration is CPU-bound on tiberius.
 
-| Direction | Original prediction | Actual | Why prediction was wrong |
-|---|---:|---:|---|
-| pg → pg | 14-16s | 25.6s | PG-target is storage-bound, not memory-bound. Slower NVMe on M3 Max dominates; larger RAM doesn't help. |
-| mssql → pg | 22-28s | 42.9s | MSSQL buffer pool wins on the read side but PG target-side writes still hit disk. Wash. |
-| pg → mssql | 80-90s | 63.8s | MSSQL target buffer pool is *more* impactful than predicted — dirty pages absorb in RAM so aggressively that the tiberius LOB INSERT path was never the real ceiling. |
-| mssql → mssql | 60-70s | 36.4s | Both sides benefit from the bigger buffer pools simultaneously; the win compounds. |
+**3. `mssql → pg` is completely insensitive to MSSQL buffer pool size
+on any host.** A: 43.3s. B: 44.6s. D: 42.9s. The target-side PG COPY
+writes hit disk regardless, and the source-side MSSQL read already has
+enough buffer pool at 3 GiB to cache the hot pages. More RAM on either
+side doesn't help.
 
-Error pattern: predictions assumed RAM helped source-read and target-write
-equally, but in practice **extra RAM only helps target-write meaningfully
-on MSSQL** (because of the checkpoint-based flush model). PG's COPY path
-bypasses `shared_buffers` aggressively enough that a bigger cache doesn't
-speed up the target side — only the source side, and the gain is small.
+**4. `pg → pg` is fundamentally storage-bound.** A: 16.5s. B: 18.0s.
+D: 25.6s (slower NVMe hurts). No amount of RAM changes this.
+
+### Remaining M5 Pro 6 GiB → M3 Max 6 GiB gap on `pg → mssql`
+
+Config C (M5 Pro) got 78.8s. Config D (M3 Max) got 63.8s with the same
+6 GiB `max server memory`. The remaining 19% gap is likely a mix of:
+
+- Run-to-run variance (~10% typical on these long Posts-dominated runs)
+- PG source host CPU differences (both native arm64, slightly different
+  per-core performance)
+- Possibly Docker Desktop version / Rosetta 2 minor revision differences
+- Not worth chasing individually — none of these are the dominant factor
 
 ### Per-table detail: `mssql → pg`
 

--- a/docs/benchmark-results-m3-max.md
+++ b/docs/benchmark-results-m3-max.md
@@ -1,8 +1,13 @@
 # Benchmark Results — M3 Max 36 GB
 
-Cross-hardware validation of `docs/benchmark-playbook.md` predictions, run on
-**M3 Max 36 GB** (Mac15,10, 14 cores) with Docker Desktop VM at **23.43 GiB**
-on 2026-04-11.
+Cross-hardware validation of [`benchmark-playbook.md`](benchmark-playbook.md)
+predictions, run on **M3 Max 36 GB** (Mac15,10, 14 cores) with Docker Desktop
+VM at **23.43 GiB** on 2026-04-11.
+
+See also: [`benchmark-playbook.md`](benchmark-playbook.md) for the
+reproduction procedure, §2 for the corrected target-write-pattern model
+that was informed by these results, and §9 for the side-by-side summary
+table.
 
 **Headline:** the playbook's §9 predictions were wrong on direction and
 magnitude, but the M3 Max still wins overall by 36% across all four

--- a/docs/tech-specs.md
+++ b/docs/tech-specs.md
@@ -309,7 +309,7 @@ _dmt_rs.table_state
   PRIMARY KEY (run_id, table_name)
 ```
 
-Indexes: one partial index on `(table_name, table_status, last_sync_timestamp) WHERE status='completed'` for fast watermark lookups on incremental sync, and one on `(config_hash, run_started_at DESC)` for latest-run lookups.
+Indexes: one partial index on `(table_name, table_status, last_sync_timestamp) WHERE table_status = 'completed' AND last_sync_timestamp IS NOT NULL` for fast watermark lookups on incremental sync, and one on `(config_hash, run_started_at DESC)` for latest-run lookups.
 
 ### Behavior
 

--- a/docs/tech-specs.md
+++ b/docs/tech-specs.md
@@ -283,33 +283,38 @@ Defined in `crates/dmt-rs/src/error.rs`. These are designed for Airflow / Kubern
 
 ## State storage
 
-Migration state is stored *in the target database* under a `_dmt_rs` schema. The schema is in `crates/dmt-rs/src/state/schema.sql` and is initialized automatically on first run.
+Migration state is stored *in the target database* under a `_dmt_rs` schema. The schema is created programmatically by `DbStateBackend::init_schema` (and the MSSQL/MySQL equivalents) in `crates/dmt-rs/src/state/`; see `crates/dmt-rs/src/state/schema.sql` for a documentation copy of the same layout.
 
 ### Tables
 
-```sql
-_dmt_rs.migration_runs
-  run_id          uuid          PRIMARY KEY
-  config_hash     text          HMAC-SHA256 of the config (used to detect drift)
-  started_at      timestamptz
-  completed_at    timestamptz   NULL until finished
-  status          text          'running' | 'completed' | 'failed' | 'cancelled'
+The schema is a **single denormalized table** `_dmt_rs.table_state`. All run-level fields (`run_id`, `run_started_at`, `run_completed_at`, `run_status`, `config_hash`) are stored on every per-table row, indexed on `(run_id, table_name)`. There is no separate `migration_runs` table.
 
+```sql
 _dmt_rs.table_state
-  run_id              uuid       FK -> migration_runs
-  table_name          text
+  run_id              text         NOT NULL
+  config_hash         text         NOT NULL    -- HMAC-SHA256 of the config (detects drift)
+  run_started_at      timestamptz  NOT NULL
+  run_completed_at    timestamptz
+  run_status          text         NOT NULL    -- 'running' | 'completed' | 'failed' | 'cancelled'
+  table_name          text         NOT NULL
+  table_status        text         NOT NULL    -- 'pending' | 'in_progress' | 'completed' | 'failed'
   rows_total          bigint
   rows_transferred    bigint
-  last_pk             bigint     For resume
-  last_sync_timestamp timestamptz  For incremental sync
-  status              text
-  error               text       NULL on success
+  rows_skipped        bigint
+  last_pk             bigint                   -- For resume
+  last_sync_timestamp timestamptz              -- For date-based incremental sync
+  table_completed_at  timestamptz
+  error               text                     -- NULL on success
+  updated_at          timestamptz  NOT NULL
+  PRIMARY KEY (run_id, table_name)
 ```
+
+Indexes: one partial index on `(table_name, table_status, last_sync_timestamp) WHERE status='completed'` for fast watermark lookups on incremental sync, and one on `(config_hash, run_started_at DESC)` for latest-run lookups.
 
 ### Behavior
 
 - State backends exist for PostgreSQL (`DbStateBackend`), MSSQL (`MssqlStateBackend`), and MySQL (`MysqlStateBackend`, `mysql` feature).
-- Multi-instance coordination is via row locking on `migration_runs`.
+- Multi-instance coordination is via row locking on `_dmt_rs.table_state`.
 - Config drift is detected via HMAC-SHA256: if the config changes between runs, `resume` fails with `MigrateError::ConfigChanged`. Use a fresh `run` to start over.
 - The schema requires no setup or manual migration — it's idempotently created on first connect.
 


### PR DESCRIPTION
Addresses all findings from [docs/benchmark-results-m3-max.md §5](../blob/main/docs/benchmark-results-m3-max.md) plus three bonus items caught during verification.

## Real functional bug

**`ssl_mode` is hardcoded in the PG reader.** `crates/dmt-rs/src/drivers/postgres/reader.rs:45` used `let ssl_mode = \"require\";` — the user's config value was never read. Any user setting `ssl_mode: disable` on a PG source was silently connecting over TLS with `NoVerifier` instead. The M3 Max review described this as a "spurious warning", but it was more than that. The writer at `writer.rs:56` was already correct (`config.ssl_mode.as_str()`); the reader wasn't. Fix is a one-line alignment.

## CLI cosmetic fix

**`health-check` hardcoded `Source (MSSQL)` / `Target (PostgreSQL)` labels** in both `main.rs` and `wizard.rs`, regardless of the actual configured types. Added `DatabaseType::display_name()` returning capitalized names ("MSSQL", "PostgreSQL", "MySQL") and wired it through both call sites. Verified against all four directions:

```
$ dmt-rs -c /tmp/dmt-rs-pg2mssql.yaml health-check
  Source (PostgreSQL): OK (0ms)
  Target (MSSQL): OK (1ms)
  Overall: HEALTHY
```

## Playbook doc fixes

1. **§2 hardware model was wrong.** Original said "memory-bound in the Docker VM" with NVMe as negligible. M3 Max results refuted both claims: slower NVMe was the dominant factor for PG-target directions. Rewritten to describe the corrected **target-write-pattern-bound** model:
   - PG targets are storage-bound (COPY flushes dirty pages direct to disk)
   - MSSQL targets are buffer-pool-bound (dirty pages absorb in RAM)

2. **§9 predictions replaced with actual results.** The original prediction table had pg→pg getting faster (it got 55% *slower*) and underestimated both MSSQL-target wins. The section now shows M5 Pro vs M3 Max side by side with an explicit "what the predictions got wrong and why" table.

3. **§7 validation query was broken.** Referenced a nonexistent `_dmt_rs.migration_runs` table. The real schema has only `_dmt_rs.table_state` with all run-level fields denormalized onto each row. Query rewritten.

4. **New gotchas §8.7, §8.8, §8.9:**
   - §8.7 — Apple Silicon NVMe bandwidth varies significantly between machines (can move benchmark numbers by 30-60%)
   - §8.8 — Pre-existing Azure SQL Edge volumes are risky to mount into SQL Server 2022; includes the safe cherry-pick procedure from `benchmark-results-m3-max.md §5.1`
   - §8.9 — Phase 4 PK creation logs `0.00s` for MSSQL targets because the PK is created inline with `CREATE TABLE`, so transfer-only vs e2e timings are not comparable across target types

5. **Cross-links** added between `benchmark-playbook.md` ↔ `benchmark-results-m3-max.md`.

## Bonus fixes caught during verification

6. **`crates/dmt-rs/src/state/schema.sql` was stale.** Described a two-table schema (`migration_runs` + `table_state`) that doesn't match the runtime. `DbStateBackend::init_schema` in `state/db.rs` creates a single denormalized `table_state`. Nothing includes this file via `include_str!`; it's documentation only. Rewritten to match runtime + a header comment noting that `db.rs` is authoritative.

7. **`docs/tech-specs.md` had the same two-table description.** Rewritten to match the actual runtime schema.

## Verification

```
cargo build --release                        ✓ clean
cargo test --all-features                    ✓ 338/338 pass
cargo fmt --check                             ✓ clean
dmt-rs health-check (all 4 directions)        ✓ correct labels
```

## Related

- [docs/benchmark-results-m3-max.md](../blob/main/docs/benchmark-results-m3-max.md) — the review that triggered this PR
- [#95](https://github.com/johndauphine/dmt-rs/pull/95) — the rename PR that landed yesterday; this PR is a follow-up

## Net diff

```
8 files changed, 322 insertions(+), 153 deletions(-)
```