### PR TITLE
fix: break transfer pipeline deadlock on writer failure

### DIFF
--- a/crates/dmt-rs/src/transfer/mod.rs
+++ b/crates/dmt-rs/src/transfer/mod.rs
@@ -20,6 +20,7 @@ use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 /// Date-based incremental sync filter.
@@ -376,6 +377,10 @@ impl TransferEngine {
             );
         }
 
+        // Per-table cancellation: when any writer fails, this token is cancelled
+        // to break the dispatcher out of its loop and unblock the entire pipeline.
+        let cancel = CancellationToken::new();
+
         // Create channel for read-ahead pipeline
         let (read_tx, read_rx) = mpsc::channel::<RowChunk>(self.config.read_ahead);
 
@@ -439,6 +444,7 @@ impl TransferEngine {
             let pk_cols_clone = pk_cols.clone();
             let target_mode = job.target_mode;
             let partition_id = job.partition_id;
+            let cancel = cancel.clone();
 
             let handle = tokio::spawn(async move {
                 let mut local_write_time = Duration::ZERO;
@@ -484,6 +490,7 @@ impl TransferEngine {
                     };
 
                     if let Err(e) = result {
+                        cancel.cancel();
                         return Err(MigrateError::transfer(
                             table_name_clone.clone(),
                             format!("Writer {} failed: {}", writer_id, e),
@@ -529,32 +536,45 @@ impl TransferEngine {
         // Use a separate receiver for the read channel
         let mut read_rx = read_rx;
 
-        while let Some(mut chunk) = read_rx.recv().await {
-            total_query_time += chunk.read_time;
-            // Track completed ranges for safe resume point calculation.
-            // Only contiguous ranges from start are considered safe.
-            range_tracker.add_range(chunk.first_pk, chunk.last_pk);
+        loop {
+            tokio::select! {
+                chunk = read_rx.recv() => {
+                    match chunk {
+                        Some(mut chunk) => {
+                            total_query_time += chunk.read_time;
+                            // Track completed ranges for safe resume point calculation.
+                            // Only contiguous ranges from start are considered safe.
+                            range_tracker.add_range(chunk.first_pk, chunk.last_pk);
 
-            // Count all rows read for progress tracking
-            let chunk_row_count = chunk.data.len() as i64;
-            if let Some(ref counter) = self.progress_counter {
-                counter.fetch_add(chunk_row_count, Ordering::Relaxed);
-            }
+                            // Count all rows read for progress tracking
+                            let chunk_row_count = chunk.data.len() as i64;
+                            if let Some(ref counter) = self.progress_counter {
+                                counter.fetch_add(chunk_row_count, Ordering::Relaxed);
+                            }
 
-            // Compress text values if enabled (reduces memory in write channel)
-            if self.config.compress_text {
-                chunk.data.compress_text_values();
-            }
+                            // Compress text values if enabled (reduces memory in write channel)
+                            if self.config.compress_text {
+                                chunk.data.compress_text_values();
+                            }
 
-            // Send rows to writers
-            if !chunk.data.is_empty() {
-                let write_job = WriteJob {
-                    data: chunk.data,
-                    partition_id: job.partition_id,
-                };
+                            // Send rows to writers
+                            if !chunk.data.is_empty() {
+                                let write_job = WriteJob {
+                                    data: chunk.data,
+                                    partition_id: job.partition_id,
+                                };
 
-                if write_tx.send(write_job).await.is_err() {
-                    // Writers have all failed
+                                if write_tx.send(write_job).await.is_err() {
+                                    // Writers have all failed
+                                    break;
+                                }
+                            }
+                        }
+                        None => break, // reader done
+                    }
+                }
+                _ = cancel.cancelled() => {
+                    // A writer failed — break to unblock the pipeline
                     break;
                 }
             }
@@ -563,18 +583,28 @@ impl TransferEngine {
         // Get the safe resume point (only contiguous ranges from start)
         let last_pk = range_tracker.safe_resume_point();
 
-        // Close write channel to signal writers to finish
+        // Close channels to unblock the entire pipeline:
+        // - drop(write_tx): writers' recv() returns Err after buffer drains
+        // - drop(read_rx): reader's send() returns Err immediately
         drop(write_tx);
+        drop(read_rx);
 
-        // Wait for reader to complete
-        match reader_handle.await {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => return Err(e),
-            Err(e) => {
-                return Err(MigrateError::Transfer {
-                    table: table_name.clone(),
-                    message: format!("Reader task failed: {}", e),
-                })
+        // Wait for reader to complete.
+        // When a writer failed (cancel is set), the reader will return
+        // "write channel closed" because we dropped read_rx — that's a
+        // symptom, not the cause. Skip it so try_join_all surfaces the
+        // real writer error below.
+        let reader_result = reader_handle.await;
+        if !cancel.is_cancelled() {
+            match reader_result {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => return Err(e),
+                Err(e) => {
+                    return Err(MigrateError::Transfer {
+                        table: table_name.clone(),
+                        message: format!("Reader task failed: {}", e),
+                    })
+                }
             }
         }
 

--- a/crates/dmt-rs/src/transfer/mod.rs
+++ b/crates/dmt-rs/src/transfer/mod.rs
@@ -602,19 +602,21 @@ impl TransferEngine {
         // Wait for reader to complete.
         // When a writer failed (cancel is set), the reader will return
         // "write channel closed" because we dropped read_rx — that's a
-        // symptom, not the cause. Skip it so try_join_all surfaces the
-        // real writer error below.
-        let reader_result = reader_handle.await;
-        if !cancel.is_cancelled() {
-            match reader_result {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => return Err(e),
-                Err(e) => {
-                    return Err(MigrateError::Transfer {
-                        table: table_name.clone(),
-                        message: format!("Reader task failed: {}", e),
-                    })
+        // symptom, not the cause. Suppress that expected error so
+        // try_join_all surfaces the real writer error below.
+        // Always propagate panics regardless of cancel state.
+        match reader_handle.await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                if !cancel.is_cancelled() {
+                    return Err(e);
                 }
+            }
+            Err(e) => {
+                return Err(MigrateError::Transfer {
+                    table: table_name.clone(),
+                    message: format!("Reader task panicked: {}", e),
+                })
             }
         }
 

--- a/crates/dmt-rs/src/transfer/mod.rs
+++ b/crates/dmt-rs/src/transfer/mod.rs
@@ -542,9 +542,8 @@ impl TransferEngine {
                     match chunk {
                         Some(mut chunk) => {
                             total_query_time += chunk.read_time;
-                            // Track completed ranges for safe resume point calculation.
-                            // Only contiguous ranges from start are considered safe.
-                            range_tracker.add_range(chunk.first_pk, chunk.last_pk);
+                            let first_pk = chunk.first_pk;
+                            let last_pk = chunk.last_pk;
 
                             // Count all rows read for progress tracking
                             let chunk_row_count = chunk.data.len() as i64;
@@ -564,11 +563,22 @@ impl TransferEngine {
                                     partition_id: job.partition_id,
                                 };
 
-                                if write_tx.send(write_job).await.is_err() {
-                                    // Writers have all failed
+                                // Wrap send in select! so a writer failure
+                                // unblocks the dispatcher even if the channel
+                                // buffer is full.
+                                let send_ok = tokio::select! {
+                                    res = write_tx.send(write_job) => res.is_ok(),
+                                    _ = cancel.cancelled() => false,
+                                };
+                                if !send_ok {
                                     break;
                                 }
                             }
+
+                            // Track range only after successful hand-off to
+                            // writers, so the resume point never advances past
+                            // data that wasn't actually queued.
+                            range_tracker.add_range(first_pk, last_pk);
                         }
                         None => break, // reader done
                     }


### PR DESCRIPTION
## Summary

- Fixes the orchestrator deadlock when a writer connection drops mid-transfer (bb8 pool timeout, PG OOM, network blip)
- Adds a per-table `CancellationToken` that any writer cancels on error, breaking the dispatcher out of its loop via `tokio::select!`
- Dispatcher drops both `write_tx` and `read_rx` on cancel, tearing down the entire reader→dispatcher→writer pipeline in milliseconds instead of hanging forever
- Suppresses the reader's "write channel closed" error on the cancel path so `try_join_all` surfaces the real writer error

## Root cause

When a writer fails, it drops its `async_channel` receiver clone — but sibling writers still hold live clones, so the channel stays open. The dispatcher blocks on `send()` (buffer full, receivers parked), the reader blocks on `send()` (dispatcher stopped consuming), and `try_join_all` waits forever.

## Verification

SO2010 `mssql→mssql` upsert (reliably triggers bb8 timeout on `dbo.Users`):

| | Before | After |
|---|---|---|
| Behavior | Hangs indefinitely at 0% CPU | Exits cleanly |
| Exit code | Never exits (or misleading rc=2) | rc=3 (`EXIT_TRANSFER_ERROR`) |
| Error message | None (silent hang) | "Writer 0 failed: Pool error: Timed out in bb8" |
| Duration | 56+ min until killed | ~90s (normal run time + prompt exit) |

## Test plan

- [x] `cargo build --release` compiles
- [x] `cargo test` — 18 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features` — no new warnings
- [x] Manual: SO2010 mssql→mssql upsert exits with rc=3 in ~90s
- [ ] Manual: pg→mssql upsert (second known trigger from #97 comment)
- [ ] Manual: mssql→pg with undersized PG container (original trigger)

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)