### PR TITLE
perf: add IS DISTINCT FROM to PG upsert to skip unchanged rows

### DIFF
--- a/crates/dmt-rs/src/drivers/postgres/writer.rs
+++ b/crates/dmt-rs/src/drivers/postgres/writer.rs
@@ -454,6 +454,15 @@ impl UpsertWriter for PostgresUpsertWriterAdapter {
             })
             .collect();
 
+        // IS DISTINCT FROM: skip rows where no non-PK column changed.
+        // Uses tuple comparison for concise SQL and planner-friendly evaluation.
+        let table_quoted = quote_ident_unchecked(&self.table);
+        let non_pk_cols: Vec<String> = cols
+            .iter()
+            .filter(|c| !pk_cols.contains(c))
+            .map(|c| quote_ident_unchecked(c))
+            .collect();
+
         let merge_sql = if update_cols.is_empty() {
             format!(
                 "INSERT INTO {} ({}) SELECT {} FROM {} ON CONFLICT ({}) DO NOTHING",
@@ -464,14 +473,22 @@ impl UpsertWriter for PostgresUpsertWriterAdapter {
                 pk_list.join(", ")
             )
         } else {
+            let target_tuple: Vec<String> = non_pk_cols
+                .iter()
+                .map(|c| format!("{}.{}", table_quoted, c))
+                .collect();
+            let excluded_tuple: Vec<String> =
+                non_pk_cols.iter().map(|c| format!("EXCLUDED.{}", c)).collect();
             format!(
-                "INSERT INTO {} ({}) SELECT {} FROM {} ON CONFLICT ({}) DO UPDATE SET {}",
+                "INSERT INTO {} ({}) SELECT {} FROM {} ON CONFLICT ({}) DO UPDATE SET {} WHERE ({}) IS DISTINCT FROM ({})",
                 qualified_target,
                 col_list.join(", "),
                 col_list.join(", "),
                 staging_quoted,
                 pk_list.join(", "),
-                update_cols.join(", ")
+                update_cols.join(", "),
+                target_tuple.join(", "),
+                excluded_tuple.join(", ")
             )
         };
 
@@ -1012,6 +1029,15 @@ impl TargetWriter for PostgresWriter {
             })
             .collect::<Result<Vec<_>>>()?;
 
+        // IS DISTINCT FROM: skip rows where no non-PK column changed.
+        // Uses tuple comparison for concise SQL and planner-friendly evaluation.
+        let table_quoted = Self::quote_ident(table)?;
+        let non_pk_cols: Vec<String> = cols
+            .iter()
+            .filter(|c| !pk_cols.contains(c))
+            .map(|c| Self::quote_ident(c))
+            .collect::<Result<Vec<_>>>()?;
+
         let upsert_sql = if update_cols.is_empty() {
             format!(
                 "INSERT INTO {} ({}) SELECT {} FROM {} ON CONFLICT ({}) DO NOTHING",
@@ -1022,14 +1048,22 @@ impl TargetWriter for PostgresWriter {
                 pk_col_list.join(", ")
             )
         } else {
+            let target_tuple: Vec<String> = non_pk_cols
+                .iter()
+                .map(|c| format!("{}.{}", table_quoted, c))
+                .collect();
+            let excluded_tuple: Vec<String> =
+                non_pk_cols.iter().map(|c| format!("EXCLUDED.{}", c)).collect();
             format!(
-                "INSERT INTO {} ({}) SELECT {} FROM {} ON CONFLICT ({}) DO UPDATE SET {}",
+                "INSERT INTO {} ({}) SELECT {} FROM {} ON CONFLICT ({}) DO UPDATE SET {} WHERE ({}) IS DISTINCT FROM ({})",
                 qualified_target,
                 col_list.join(", "),
                 col_list.join(", "),
                 quote_ident_unchecked(&staging_name),
                 pk_col_list.join(", "),
-                update_cols.join(", ")
+                update_cols.join(", "),
+                target_tuple.join(", "),
+                excluded_tuple.join(", ")
             )
         };
 


### PR DESCRIPTION
## Summary

- Adds `WHERE (...) IS DISTINCT FROM (...)` to PostgreSQL `INSERT...ON CONFLICT DO UPDATE` so unchanged rows are skipped entirely — no unnecessary WAL writes
- Both PG upsert codepaths updated (legacy `UpsertWriter` + current `TargetWriter`)
- Uses tuple-level comparison matching Go dmt's strategy for NULL-safe, planner-friendly evaluation

## Benchmark (SO2010 pg→pg upsert, pre-populated target)

| Metric | Before | After | Go dmt |
|---|---:|---:|---:|
| Duration | 66s | **38s** | 18s |
| Throughput | 293k rows/s | **517k rows/s** | 1.07M rows/s |
| vs Go | 3.67× slower | **2.1× slower** | — |

Remaining 2.1× gap is in pipeline-level differences (adaptive COPY sub-batching, pgx driver optimizations), not SQL generation. Go dmt uses the same staging table + IS DISTINCT FROM strategy — confirmed by code review of `/internal/driver/postgres/writer.go`.

## Generated SQL (before → after)

```sql
-- Before: always updates non-PK columns
INSERT INTO "public"."posts" (id, title, body)
SELECT id, title, body FROM _staging_posts_0
ON CONFLICT (id) DO UPDATE SET title = EXCLUDED.title, body = EXCLUDED.body;

-- After: skips unchanged rows via tuple comparison
INSERT INTO "public"."posts" (id, title, body)
SELECT id, title, body FROM _staging_posts_0
ON CONFLICT (id) DO UPDATE SET title = EXCLUDED.title, body = EXCLUDED.body
WHERE ("posts".title, "posts".body) IS DISTINCT FROM (EXCLUDED.title, EXCLUDED.body);
```

## Test plan

- [x] `cargo build --release` compiles
- [x] `cargo test` — all pass
- [x] `cargo clippy --all-targets --all-features` — no new warnings
- [x] Benchmark: pg→pg upsert 66s → 38s
- [x] Gemini CLI review — no issues found (SQL correctness, NULL handling, quoting, edge cases all clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)