### PR TITLE
fix: cap parallel_writers for MSSQL upsert to prevent bb8 pool timeout

### DIFF
--- a/crates/dmt-rs/src/drivers/mssql/writer.rs
+++ b/crates/dmt-rs/src/drivers/mssql/writer.rs
@@ -41,7 +41,7 @@ const DEADLOCK_RETRY_DELAY_MS: u64 = 200;
 const TDS_MAX_PACKET_SIZE: u32 = 32767;
 
 /// Connection pool timeouts.
-const POOL_CONNECTION_TIMEOUT: Duration = Duration::from_secs(30);
+const POOL_CONNECTION_TIMEOUT: Duration = Duration::from_secs(120);
 const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
 const POOL_MAX_LIFETIME: Duration = Duration::from_secs(1800);
 const TCP_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);

--- a/crates/dmt-rs/src/orchestrator/mod.rs
+++ b/crates/dmt-rs/src/orchestrator/mod.rs
@@ -917,11 +917,28 @@ impl Orchestrator {
             }
         });
 
+        // Cap parallel_writers to 1 for MSSQL upsert: MERGE WITH (TABLOCK) acquires
+        // an exclusive table lock, so >1 writer per partition just queues on the lock
+        // while holding pool connections — causing bb8 timeout under load.
+        let configured_writers = self.config.migration.get_write_ahead_writers();
+        let is_mssql_upsert = matches!(self.target, TargetPoolImpl::Mssql(_))
+            && self.config.migration.target_mode == TargetMode::Upsert;
+        let parallel_writers = if is_mssql_upsert && configured_writers > 1 {
+            info!(
+                "Capping parallel_writers to 1 for MSSQL upsert \
+                 (MERGE WITH TABLOCK serializes writers; {} configured)",
+                configured_writers
+            );
+            1
+        } else {
+            configured_writers
+        };
+
         let transfer_config = TransferConfig {
             chunk_size: self.config.migration.get_chunk_size(),
             read_ahead: self.config.migration.get_read_ahead_buffers(),
             parallel_readers: self.config.migration.get_parallel_readers(),
-            parallel_writers: self.config.migration.get_write_ahead_writers(),
+            parallel_writers,
             use_copy_binary: true, // Enable COPY TO BINARY for PostgreSQL sources
             compress_text: self.config.migration.compress_text,
         };


### PR DESCRIPTION
## Summary

- Caps `parallel_writers` to 1 when target is MSSQL and mode is `upsert` — MERGE WITH (TABLOCK) acquires an exclusive table lock, so multiple writers per partition just queue on the lock while holding pool connections, causing bb8 timeout
- Increases bb8 `POOL_CONNECTION_TIMEOUT` from 30s to 120s as safety net for cross-partition TABLOCK contention
- Uses `matches!(self.target, TargetPoolImpl::Mssql(_))` for robust target detection (per Gemini review)

## Root cause

With `write_ahead_writers=2` (auto-tuned for MSSQL) and 3 partitions per large table, 6 concurrent MERGE operations compete for the same exclusive table lock. Each blocked writer holds a pool connection. The 30-second bb8 timeout fires when connections can't be recycled fast enough. Drop_recreate mode is unaffected (bulk INSERT is fast, no TABLOCK contention).

## Results (SO2010 mssql→mssql upsert)

| Metric | Before | After |
|---|---|---|
| Tables completed | 0/9 | **7/9** |
| Rows transferred | 1.3M | **15.6M** |
| Outcome | bb8 timeout on every table | All tables except Posts |
| Exit behavior | Hangs (pre-#98) or partial exit | Clean exit, rc=3 |

Posts fails due to a **separate** tiberius encoding bug (`unrepresentable character` in nvarchar(max) LOB data), not pool timeout.

## Test plan

- [x] `cargo build --release` compiles
- [x] `cargo test` — all pass
- [x] `cargo clippy --all-targets --all-features` — no new warnings
- [x] Manual: SO2010 mssql→mssql upsert — 7/9 tables complete (was: 0/9)
- [x] Gemini CLI review — approved with one suggestion (enum matching, implemented)
- [ ] Manual: SO2010 mssql→mssql drop_recreate unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)