### PR TITLE
feat: AI-powered type mapping with persistent cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +795,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +837,7 @@ dependencies = [
  "bytes",
  "chrono",
  "deadpool-postgres",
+ "dirs",
  "futures",
  "glob",
  "hex",
@@ -817,6 +845,7 @@ dependencies = [
  "lz4_flex",
  "mysql_async",
  "postgres-types",
+ "reqwest",
  "rust_decimal",
  "rustls 0.23.35",
  "serde",
@@ -1146,9 +1175,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1208,6 +1239,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls 0.23.35",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower-service",
+ "webpki-roots 1.0.4",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.1",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1375,6 +1504,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,6 +1676,12 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
@@ -1751,6 +1902,12 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking"
@@ -2009,6 +2166,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.35",
+ "socket2 0.6.1",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.35",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.1",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,6 +2360,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2183,6 +2406,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.35",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -2341,6 +2602,7 @@ version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2479,6 +2741,18 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2723,6 +2997,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -3045,6 +3328,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,6 +3446,12 @@ dependencies = [
  "tracing-log",
  "tracing-serde",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
@@ -3274,6 +3608,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3305,6 +3648,19 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3344,6 +3700,16 @@ name = "web-sys"
 version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3524,6 +3890,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3556,6 +3931,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3593,6 +3983,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3605,6 +4001,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3614,6 +4016,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3641,6 +4049,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3650,6 +4064,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3665,6 +4085,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3674,6 +4100,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/benchmark-pg-pg-config.yaml
+++ b/benchmark-pg-pg-config.yaml
@@ -1,0 +1,32 @@
+# Benchmark: PostgreSQL to PostgreSQL
+# Dataset: StackOverflow2013 (~106M rows)
+# Source: pg-bench container (port 5432)
+# Target: pg-target container (port 5434)
+
+source:
+  type: postgres
+  host: localhost
+  port: 5432
+  database: so2013
+  user: postgres
+  password: "TestPass2024"
+  schema: public
+  ssl_mode: disable
+
+target:
+  type: postgres
+  host: localhost
+  port: 5434
+  database: so2013_bench
+  user: postgres
+  password: "TestPass2024"
+  schema: public
+  ssl_mode: disable
+
+migration:
+  target_mode: drop_recreate
+  workers: 6
+  chunk_size: 100000
+  parallel_readers: 12
+  parallel_writers: 8
+  max_pg_connections: 40

--- a/crates/dmt-rs-cli/Cargo.toml
+++ b/crates/dmt-rs-cli/Cargo.toml
@@ -16,6 +16,7 @@ default = []
 tui = ["ratatui", "crossterm", "fuzzy-matcher"]
 kerberos = ["dmt-rs/kerberos"]
 mysql = ["dmt-rs/mysql"]
+ai = ["dmt-rs/ai"]
 
 [dependencies]
 dmt-rs = { path = "../dmt-rs" }

--- a/crates/dmt-rs-cli/src/main.rs
+++ b/crates/dmt-rs-cli/src/main.rs
@@ -26,6 +26,10 @@ struct Cli {
     #[arg(short, long, default_value = "config.yaml")]
     config: PathBuf,
 
+    /// Path to global configuration file (default: ~/.dmt-rs/dmt-rs-config.yaml)
+    #[arg(long)]
+    global_config: Option<PathBuf>,
+
     /// Output JSON result to stdout
     #[arg(long)]
     output_json: bool,
@@ -173,6 +177,20 @@ async fn run() -> Result<(), MigrateError> {
     setup_logging(&cli.verbosity, &cli.log_format)
         .map_err(|e| MigrateError::Config(e.to_string()))?;
 
+    // Load global configuration (AI settings, etc.) from ~/.dmt-rs/dmt-rs-config.yaml
+    // or the path specified by --global-config.
+    #[cfg(feature = "ai")]
+    let global_config = {
+        let global_path = cli.global_config.clone().unwrap_or_else(
+            dmt_rs::ai::GlobalConfig::default_path
+        );
+        let gc = dmt_rs::ai::GlobalConfig::load(&global_path)?;
+        if gc.ai.is_some() {
+            info!("Loaded global config from {:?} (AI enabled)", global_path);
+        }
+        gc
+    };
+
     // Load configuration with initial auto-tuning for connection pool sizes.
     // Will be re-tuned after schema extraction with actual row sizes.
     let mut config = Config::load(&cli.config)?.with_auto_tuning();
@@ -204,6 +222,12 @@ async fn run() -> Result<(), MigrateError> {
 
             // Create orchestrator (automatically initializes database state schema)
             let mut orchestrator = Orchestrator::new(config).await?;
+
+            // Enable AI type mapping if configured
+            #[cfg(feature = "ai")]
+            if let Some(ai_config) = &global_config.ai {
+                orchestrator = orchestrator.with_ai_config(ai_config);
+            }
 
             // Auto-resume from database state if it exists
             // This makes 'run' idempotent and enables incremental sync workflows:

--- a/crates/dmt-rs-cli/src/main.rs
+++ b/crates/dmt-rs-cli/src/main.rs
@@ -27,6 +27,7 @@ struct Cli {
     config: PathBuf,
 
     /// Path to global configuration file (default: ~/.dmt-rs/dmt-rs-config.yaml)
+    #[cfg(feature = "ai")]
     #[arg(long)]
     global_config: Option<PathBuf>,
 

--- a/crates/dmt-rs/Cargo.toml
+++ b/crates/dmt-rs/Cargo.toml
@@ -17,6 +17,8 @@ default = []
 kerberos = ["tiberius/integrated-auth-gssapi"]
 # MySQL/MariaDB support via mysql_async (with LOAD DATA LOCAL INFILE)
 mysql = ["dep:mysql_async"]
+# AI-powered type mapping via LLM providers (Anthropic, OpenAI, Ollama, LM Studio)
+ai = ["dep:reqwest", "dep:dirs"]
 
 [dependencies]
 # Async runtime
@@ -87,6 +89,10 @@ lz4_flex = "0.11"
 
 # MySQL/MariaDB driver (optional) - uses mysql_async for LOAD DATA LOCAL INFILE
 mysql_async = { workspace = true, optional = true }
+
+# AI type mapping (optional)
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
+dirs = { version = "5", optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/dmt-rs/src/ai/cache.rs
+++ b/crates/dmt-rs/src/ai/cache.rs
@@ -1,0 +1,260 @@
+use crate::error::{MigrateError, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+use tracing::{debug, info, warn};
+
+/// Cache key uniquely identifying a type mapping request.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CacheKey {
+    pub source_db: String,
+    pub target_db: String,
+    pub source_type: String,
+    pub max_length: i32,
+    pub precision: i32,
+    pub scale: i32,
+}
+
+impl CacheKey {
+    pub fn new(
+        source_db: &str,
+        target_db: &str,
+        source_type: &str,
+        max_length: i32,
+        precision: i32,
+        scale: i32,
+    ) -> Self {
+        Self {
+            source_db: source_db.to_lowercase(),
+            target_db: target_db.to_lowercase(),
+            source_type: source_type.to_lowercase(),
+            max_length,
+            precision,
+            scale,
+        }
+    }
+
+    /// String key for JSON serialization.
+    fn to_string_key(&self) -> String {
+        format!(
+            "{}|{}|{}|{}|{}|{}",
+            self.source_db, self.target_db, self.source_type,
+            self.max_length, self.precision, self.scale
+        )
+    }
+
+    /// Parse from string key.
+    fn from_string_key(s: &str) -> Option<Self> {
+        let parts: Vec<&str> = s.split('|').collect();
+        if parts.len() != 6 {
+            return None;
+        }
+        Some(Self {
+            source_db: parts[0].to_string(),
+            target_db: parts[1].to_string(),
+            source_type: parts[2].to_string(),
+            max_length: parts[3].parse().ok()?,
+            precision: parts[4].parse().ok()?,
+            scale: parts[5].parse().ok()?,
+        })
+    }
+}
+
+/// Cached type mapping result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CacheEntry {
+    pub target_type: String,
+    pub created_at: String,
+}
+
+/// In-memory + persistent disk cache for AI type mapping results.
+pub struct TypeCache {
+    memory: RwLock<HashMap<CacheKey, CacheEntry>>,
+    file_path: PathBuf,
+}
+
+impl TypeCache {
+    /// Load cache from disk, or create empty if file doesn't exist or is corrupt.
+    pub fn load(path: &Path) -> Self {
+        let memory = if path.exists() {
+            match std::fs::read_to_string(path) {
+                Ok(content) => {
+                    match serde_json::from_str::<HashMap<String, CacheEntry>>(&content) {
+                        Ok(disk_map) => {
+                            let mut mem = HashMap::new();
+                            for (key_str, entry) in disk_map {
+                                if let Some(key) = CacheKey::from_string_key(&key_str) {
+                                    mem.insert(key, entry);
+                                }
+                            }
+                            info!("Loaded {} entries from AI type cache {:?}", mem.len(), path);
+                            mem
+                        }
+                        Err(e) => {
+                            warn!("Failed to parse AI type cache {:?}: {}. Starting fresh.", path, e);
+                            HashMap::new()
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("Failed to read AI type cache {:?}: {}. Starting fresh.", path, e);
+                    HashMap::new()
+                }
+            }
+        } else {
+            HashMap::new()
+        };
+
+        Self {
+            memory: RwLock::new(memory),
+            file_path: path.to_path_buf(),
+        }
+    }
+
+    /// Look up a cached type mapping (sync, non-blocking read).
+    pub fn get(&self, key: &CacheKey) -> Option<CacheEntry> {
+        self.memory.read().unwrap().get(key).cloned()
+    }
+
+    /// Insert a single entry and flush to disk.
+    pub fn insert(&self, key: CacheKey, entry: CacheEntry) -> Result<()> {
+        {
+            let mut mem = self.memory.write().unwrap();
+            mem.insert(key, entry);
+        }
+        self.flush()
+    }
+
+    /// Insert a batch of entries and flush once.
+    pub fn insert_batch(&self, entries: Vec<(CacheKey, CacheEntry)>) -> Result<()> {
+        if entries.is_empty() {
+            return Ok(());
+        }
+        {
+            let mut mem = self.memory.write().unwrap();
+            for (key, entry) in entries {
+                mem.insert(key, entry);
+            }
+        }
+        self.flush()
+    }
+
+    /// Check if a key exists in the cache.
+    pub fn contains(&self, key: &CacheKey) -> bool {
+        self.memory.read().unwrap().contains_key(key)
+    }
+
+    /// Number of entries in the cache.
+    pub fn len(&self) -> usize {
+        self.memory.read().unwrap().len()
+    }
+
+    /// Flush the in-memory cache to disk.
+    fn flush(&self) -> Result<()> {
+        let mem = self.memory.read().unwrap();
+        let disk_map: HashMap<String, &CacheEntry> = mem
+            .iter()
+            .map(|(k, v)| (k.to_string_key(), v))
+            .collect();
+
+        // Ensure parent directory exists with secure permissions
+        if let Some(parent) = self.file_path.parent() {
+            if !parent.exists() {
+                std::fs::create_dir_all(parent)?;
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))?;
+                }
+            }
+        }
+
+        let json = serde_json::to_string_pretty(&disk_map)
+            .map_err(|e| MigrateError::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Failed to serialize type cache: {}", e),
+            )))?;
+
+        // Atomic write: write to temp file, then rename
+        let tmp_path = self.file_path.with_extension("json.tmp");
+        std::fs::write(&tmp_path, &json)?;
+        std::fs::rename(&tmp_path, &self.file_path)?;
+
+        // Set cache file to 600 (owner read/write only)
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&self.file_path, std::fs::Permissions::from_mode(0o600))?;
+        }
+
+        debug!("Flushed {} entries to AI type cache {:?}", mem.len(), self.file_path);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_cache_key_roundtrip() {
+        let key = CacheKey::new("mssql", "postgres", "hierarchyid", 0, 0, 0);
+        let s = key.to_string_key();
+        let parsed = CacheKey::from_string_key(&s).unwrap();
+        assert_eq!(key, parsed);
+    }
+
+    #[test]
+    fn test_cache_insert_and_get() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("cache.json");
+        let cache = TypeCache::load(&path);
+
+        let key = CacheKey::new("mssql", "postgres", "hierarchyid", 0, 0, 0);
+        let entry = CacheEntry {
+            target_type: "text".to_string(),
+            created_at: "2026-04-14T00:00:00Z".to_string(),
+        };
+
+        assert!(cache.get(&key).is_none());
+        cache.insert(key.clone(), entry.clone()).unwrap();
+        assert_eq!(cache.get(&key).unwrap().target_type, "text");
+
+        // Verify persisted to disk
+        let cache2 = TypeCache::load(&path);
+        assert_eq!(cache2.get(&key).unwrap().target_type, "text");
+    }
+
+    #[test]
+    fn test_cache_batch_insert() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("cache.json");
+        let cache = TypeCache::load(&path);
+
+        let entries = vec![
+            (
+                CacheKey::new("mssql", "postgres", "hierarchyid", 0, 0, 0),
+                CacheEntry { target_type: "text".to_string(), created_at: "2026-04-14".to_string() },
+            ),
+            (
+                CacheKey::new("mssql", "postgres", "geography", 0, 0, 0),
+                CacheEntry { target_type: "text".to_string(), created_at: "2026-04-14".to_string() },
+            ),
+        ];
+
+        cache.insert_batch(entries).unwrap();
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn test_cache_corrupt_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("cache.json");
+        std::fs::write(&path, "not json").unwrap();
+
+        let cache = TypeCache::load(&path);
+        assert_eq!(cache.len(), 0); // Should start fresh
+    }
+}

--- a/crates/dmt-rs/src/ai/cache.rs
+++ b/crates/dmt-rs/src/ai/cache.rs
@@ -176,17 +176,28 @@ impl TypeCache {
                 format!("Failed to serialize type cache: {}", e),
             )))?;
 
-        // Atomic write: write to temp file, then rename
+        // Atomic write: write to temp file with 600 permissions, then rename.
+        // Creating the temp file with restricted mode from the start avoids
+        // a window where schema/type details are world-readable.
         let tmp_path = self.file_path.with_extension("json.tmp");
-        std::fs::write(&tmp_path, &json)?;
-        std::fs::rename(&tmp_path, &self.file_path)?;
 
-        // Set cache file to 600 (owner read/write only)
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&self.file_path, std::fs::Permissions::from_mode(0o600))?;
+            use std::io::Write;
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(&tmp_path)?;
+            file.write_all(json.as_bytes())?;
         }
+
+        #[cfg(not(unix))]
+        std::fs::write(&tmp_path, &json)?;
+
+        std::fs::rename(&tmp_path, &self.file_path)?;
 
         debug!("Flushed {} entries to AI type cache {:?}", mem.len(), self.file_path);
         Ok(())

--- a/crates/dmt-rs/src/ai/config.rs
+++ b/crates/dmt-rs/src/ai/config.rs
@@ -1,0 +1,254 @@
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Global application configuration (loaded from ~/.dmt-rs/dmt-rs-config.yaml).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GlobalConfig {
+    /// AI configuration for type mapping and error diagnosis.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ai: Option<AiConfig>,
+}
+
+/// AI provider and model configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiConfig {
+    /// API key. Supports ${env:VAR_NAME} syntax for environment variable expansion.
+    #[serde(default)]
+    pub api_key: String,
+
+    /// Provider: anthropic (default), openai, ollama, lmstudio
+    #[serde(default)]
+    pub provider: AiProvider,
+
+    /// Model name (optional, sensible defaults per provider)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    /// Base URL override (for ollama, lmstudio, or custom endpoints)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+
+    /// Cache file path (default: ~/.dmt-rs/type-cache.json)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum AiProvider {
+    #[default]
+    Anthropic,
+    #[serde(alias = "openai")]
+    OpenAI,
+    Ollama,
+    #[serde(alias = "lmstudio", alias = "lm_studio")]
+    LMStudio,
+}
+
+impl AiConfig {
+    /// Resolve the API key, expanding ${env:VAR_NAME} references.
+    pub fn resolve_api_key(&self) -> String {
+        expand_env_vars(&self.api_key)
+    }
+
+    /// Get the cache file path, defaulting to ~/.dmt-rs/type-cache.json.
+    pub fn cache_path(&self) -> PathBuf {
+        if let Some(ref path) = self.cache_path {
+            PathBuf::from(expand_env_vars(path))
+        } else {
+            default_cache_path()
+        }
+    }
+
+    /// Get the default model for the configured provider.
+    pub fn model_or_default(&self) -> String {
+        if let Some(ref model) = self.model {
+            return model.clone();
+        }
+        match self.provider {
+            AiProvider::Anthropic => "claude-haiku-4-5-20251001".to_string(),
+            AiProvider::OpenAI => "gpt-4o".to_string(),
+            AiProvider::Ollama => "llama3.1".to_string(),
+            AiProvider::LMStudio => "default".to_string(),
+        }
+    }
+
+    /// Get the base URL for the configured provider.
+    pub fn base_url_or_default(&self) -> String {
+        if let Some(ref url) = self.base_url {
+            return url.clone();
+        }
+        match self.provider {
+            AiProvider::Anthropic => "https://api.anthropic.com".to_string(),
+            AiProvider::OpenAI => "https://api.openai.com".to_string(),
+            AiProvider::Ollama => "http://localhost:11434".to_string(),
+            AiProvider::LMStudio => "http://localhost:1234".to_string(),
+        }
+    }
+}
+
+impl GlobalConfig {
+    /// Load global config from a file path. Returns default if file doesn't exist.
+    ///
+    /// Warns if the file has overly permissive permissions (readable by group/others),
+    /// since it may contain API keys.
+    pub fn load(path: &Path) -> crate::error::Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+
+        // Check file permissions on Unix — warn if group/world readable
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Ok(metadata) = std::fs::metadata(path) {
+                let mode = metadata.permissions().mode();
+                if mode & 0o077 != 0 {
+                    tracing::warn!(
+                        "Global config {:?} has overly permissive permissions ({:o}). \
+                         This file may contain API keys. Run: chmod 600 {:?}",
+                        path, mode & 0o777, path
+                    );
+                }
+            }
+        }
+
+        let content = std::fs::read_to_string(path)?;
+        let config: GlobalConfig = serde_yaml::from_str(&content)
+            .map_err(|e| crate::error::MigrateError::Config(
+                format!("Failed to parse global config {:?}: {}", path, e)
+            ))?;
+        Ok(config)
+    }
+
+    /// Default global config file path: ~/.dmt-rs/dmt-rs-config.yaml
+    pub fn default_path() -> PathBuf {
+        dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".dmt-rs")
+            .join("dmt-rs-config.yaml")
+    }
+
+    /// Ensure the config directory exists with secure permissions (700).
+    pub fn ensure_config_dir() -> crate::error::Result<PathBuf> {
+        let dir = dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".dmt-rs");
+
+        if !dir.exists() {
+            std::fs::create_dir_all(&dir)?;
+
+            // Set directory to 700 (owner only) on Unix
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))?;
+            }
+
+            tracing::info!("Created config directory {:?} with restricted permissions", dir);
+        }
+
+        Ok(dir)
+    }
+
+    /// Write a global config file with secure permissions (600).
+    pub fn save(&self, path: &Path) -> crate::error::Result<()> {
+        // Ensure parent directory exists with secure permissions
+        if let Some(parent) = path.parent() {
+            if !parent.exists() {
+                Self::ensure_config_dir()?;
+            }
+        }
+
+        let content = serde_yaml::to_string(self)
+            .map_err(|e| crate::error::MigrateError::Config(
+                format!("Failed to serialize global config: {}", e)
+            ))?;
+
+        std::fs::write(path, &content)?;
+
+        // Set file to 600 (owner read/write only) on Unix
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Expand ${env:VAR_NAME} references in a string.
+fn expand_env_vars(s: &str) -> String {
+    let mut result = s.to_string();
+    // Match ${env:VAR_NAME} pattern
+    while let Some(start) = result.find("${env:") {
+        if let Some(end) = result[start..].find('}') {
+            let var_name = &result[start + 6..start + end];
+            let value = std::env::var(var_name).unwrap_or_default();
+            result = format!("{}{}{}", &result[..start], value, &result[start + end + 1..]);
+        } else {
+            break;
+        }
+    }
+    result
+}
+
+/// Default cache path: ~/.dmt-rs/type-cache.json
+fn default_cache_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".dmt-rs")
+        .join("type-cache.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_expand_env_vars() {
+        std::env::set_var("DMT_TEST_KEY", "test_value");
+        assert_eq!(expand_env_vars("${env:DMT_TEST_KEY}"), "test_value");
+        assert_eq!(expand_env_vars("prefix_${env:DMT_TEST_KEY}_suffix"), "prefix_test_value_suffix");
+        assert_eq!(expand_env_vars("no_expansion"), "no_expansion");
+        assert_eq!(expand_env_vars("${env:DMT_NONEXISTENT}"), "");
+        std::env::remove_var("DMT_TEST_KEY");
+    }
+
+    #[test]
+    fn test_default_models() {
+        let config = AiConfig {
+            api_key: String::new(),
+            provider: AiProvider::Anthropic,
+            model: None,
+            base_url: None,
+            cache_path: None,
+        };
+        assert_eq!(config.model_or_default(), "claude-haiku-4-5-20251001");
+
+        let config = AiConfig { provider: AiProvider::OpenAI, ..config.clone() };
+        assert_eq!(config.model_or_default(), "gpt-4o");
+    }
+
+    #[test]
+    fn test_deserialize_providers() {
+        let yaml = "provider: anthropic";
+        let config: AiConfig = serde_yaml::from_str(&format!("api_key: test\n{}", yaml)).unwrap();
+        assert_eq!(config.provider, AiProvider::Anthropic);
+
+        let yaml = "provider: openai";
+        let config: AiConfig = serde_yaml::from_str(&format!("api_key: test\n{}", yaml)).unwrap();
+        assert_eq!(config.provider, AiProvider::OpenAI);
+
+        let yaml = "provider: lmstudio";
+        let config: AiConfig = serde_yaml::from_str(&format!("api_key: test\n{}", yaml)).unwrap();
+        assert_eq!(config.provider, AiProvider::LMStudio);
+    }
+
+    #[test]
+    fn test_global_config_default_on_missing_file() {
+        let config = GlobalConfig::load(Path::new("/nonexistent/path.yaml")).unwrap();
+        assert!(config.ai.is_none());
+    }
+}

--- a/crates/dmt-rs/src/ai/config.rs
+++ b/crates/dmt-rs/src/ai/config.rs
@@ -47,8 +47,19 @@ pub enum AiProvider {
 
 impl AiConfig {
     /// Resolve the API key, expanding ${env:VAR_NAME} references.
+    /// Falls back to provider-specific environment variables if api_key is empty.
     pub fn resolve_api_key(&self) -> String {
-        expand_env_vars(&self.api_key)
+        let key = expand_env_vars(&self.api_key);
+        if !key.is_empty() {
+            return key;
+        }
+        // Fallback to provider-specific env vars
+        let env_var = match self.provider {
+            AiProvider::Anthropic => "ANTHROPIC_API_KEY",
+            AiProvider::OpenAI => "OPENAI_API_KEY",
+            AiProvider::Ollama | AiProvider::LMStudio => return String::new(),
+        };
+        std::env::var(env_var).unwrap_or_default()
     }
 
     /// Get the cache file path, defaulting to ~/.dmt-rs/type-cache.json.
@@ -130,6 +141,7 @@ impl GlobalConfig {
     }
 
     /// Ensure the config directory exists with secure permissions (700).
+    /// Warns if an existing directory has overly permissive permissions.
     pub fn ensure_config_dir() -> crate::error::Result<PathBuf> {
         let dir = dirs::home_dir()
             .unwrap_or_else(|| PathBuf::from("."))
@@ -138,7 +150,6 @@ impl GlobalConfig {
         if !dir.exists() {
             std::fs::create_dir_all(&dir)?;
 
-            // Set directory to 700 (owner only) on Unix
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
@@ -146,12 +157,29 @@ impl GlobalConfig {
             }
 
             tracing::info!("Created config directory {:?} with restricted permissions", dir);
+        } else {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                if let Ok(metadata) = std::fs::metadata(&dir) {
+                    let mode = metadata.permissions().mode();
+                    if mode & 0o077 != 0 {
+                        tracing::warn!(
+                            "Config directory {:?} has overly permissive permissions ({:o}). \
+                             This directory may contain API keys. Run: chmod 700 {:?}",
+                            dir, mode & 0o777, dir
+                        );
+                    }
+                }
+            }
         }
 
         Ok(dir)
     }
 
     /// Write a global config file with secure permissions (600).
+    /// On Unix, the file is created with mode 600 from the start to avoid
+    /// a window where it's readable by others.
     pub fn save(&self, path: &Path) -> crate::error::Result<()> {
         // Ensure parent directory exists with secure permissions
         if let Some(parent) = path.parent() {
@@ -165,14 +193,22 @@ impl GlobalConfig {
                 format!("Failed to serialize global config: {}", e)
             ))?;
 
-        std::fs::write(path, &content)?;
-
-        // Set file to 600 (owner read/write only) on Unix
+        // Write with restricted permissions from the start
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+            use std::io::Write;
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(path)?;
+            file.write_all(content.as_bytes())?;
         }
+
+        #[cfg(not(unix))]
+        std::fs::write(path, &content)?;
 
         Ok(())
     }

--- a/crates/dmt-rs/src/ai/mapper.rs
+++ b/crates/dmt-rs/src/ai/mapper.rs
@@ -1,0 +1,187 @@
+use crate::ai::cache::{CacheEntry, CacheKey, TypeCache};
+use crate::ai::provider::AiProviderClient;
+use crate::core::schema::{Column, Table};
+use crate::core::traits::{ColumnMapping, TypeMapper, TypeMapping};
+use crate::error::Result;
+use std::collections::HashSet;
+use std::sync::Arc;
+use tracing::{debug, info, warn};
+
+/// AI-powered type mapper that wraps a static mapper with LLM fallback.
+///
+/// The static mapper is tried first. If it returns a fallback/unknown type,
+/// the AI cache is consulted. The cache is populated during a warm-up phase
+/// before DDL generation.
+pub struct AiTypeMapper {
+    inner: Arc<dyn TypeMapper>,
+    cache: Arc<TypeCache>,
+}
+
+impl AiTypeMapper {
+    /// Create a new AI type mapper wrapping an existing static mapper.
+    pub fn new(inner: Arc<dyn TypeMapper>, cache: Arc<TypeCache>) -> Self {
+        Self { inner, cache }
+    }
+
+    /// Pre-populate cache for all unknown types found in the schema.
+    /// Called after schema extraction, before DDL generation.
+    pub async fn warm_up(
+        &self,
+        tables: &[Table],
+        provider: &dyn AiProviderClient,
+    ) -> Result<()> {
+        // Collect all unique type signatures across all tables
+        let mut unknown_keys: HashSet<CacheKey> = HashSet::new();
+
+        for table in tables {
+            for col in &table.columns {
+                let mapping = self.inner.map_type(
+                    &col.data_type,
+                    col.max_length,
+                    col.precision,
+                    col.scale,
+                );
+
+                if mapping.is_fallback {
+                    let key = CacheKey::new(
+                        self.inner.source_dialect(),
+                        self.inner.target_dialect(),
+                        &col.data_type,
+                        col.max_length,
+                        col.precision,
+                        col.scale,
+                    );
+
+                    // Skip if already cached
+                    if !self.cache.contains(&key) {
+                        unknown_keys.insert(key);
+                    }
+                }
+            }
+        }
+
+        if unknown_keys.is_empty() {
+            debug!("AI warm-up: no unknown types found, skipping");
+            return Ok(());
+        }
+
+        info!(
+            "AI warm-up: resolving {} unknown type(s) via {}→{}",
+            unknown_keys.len(),
+            self.inner.source_dialect(),
+            self.inner.target_dialect()
+        );
+
+        // Call AI for each unknown type
+        let mut new_entries = Vec::new();
+        for key in &unknown_keys {
+            match provider
+                .map_type(
+                    &key.source_db,
+                    &key.target_db,
+                    &key.source_type,
+                    key.max_length,
+                    key.precision,
+                    key.scale,
+                )
+                .await
+            {
+                Ok(target_type) => {
+                    info!(
+                        "AI mapped: {} ({}) -> {} ({})",
+                        key.source_type, key.source_db, target_type, key.target_db
+                    );
+                    new_entries.push((
+                        key.clone(),
+                        CacheEntry {
+                            target_type,
+                            created_at: chrono::Utc::now().to_rfc3339(),
+                        },
+                    ));
+                }
+                Err(e) => {
+                    warn!(
+                        "AI failed to map type '{}' ({}→{}): {}. Using static fallback.",
+                        key.source_type, key.source_db, key.target_db, e
+                    );
+                }
+            }
+        }
+
+        if !new_entries.is_empty() {
+            info!("AI warm-up: caching {} new type mapping(s)", new_entries.len());
+            self.cache.insert_batch(new_entries)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl TypeMapper for AiTypeMapper {
+    fn source_dialect(&self) -> &str {
+        self.inner.source_dialect()
+    }
+
+    fn target_dialect(&self) -> &str {
+        self.inner.target_dialect()
+    }
+
+    fn map_type(
+        &self,
+        data_type: &str,
+        max_length: i32,
+        precision: i32,
+        scale: i32,
+    ) -> TypeMapping {
+        // Step 1: Try static mapper
+        let result = self.inner.map_type(data_type, max_length, precision, scale);
+
+        // Step 2: If fallback, check AI cache
+        if result.is_fallback {
+            let key = CacheKey::new(
+                self.inner.source_dialect(),
+                self.inner.target_dialect(),
+                data_type,
+                max_length,
+                precision,
+                scale,
+            );
+
+            if let Some(entry) = self.cache.get(&key) {
+                debug!(
+                    "AI cache hit: {} -> {} ({}→{})",
+                    data_type, entry.target_type,
+                    self.inner.source_dialect(),
+                    self.inner.target_dialect()
+                );
+                return TypeMapping {
+                    target_type: entry.target_type,
+                    is_lossy: true,
+                    warning: Some(format!("AI-mapped from '{}' (static mapper had no mapping)", data_type)),
+                    is_fallback: false, // AI resolved it
+                };
+            }
+
+            // Cache miss: warn but return the static fallback
+            debug!(
+                "AI cache miss for '{}' ({}→{}), using static fallback: {}",
+                data_type,
+                self.inner.source_dialect(),
+                self.inner.target_dialect(),
+                result.target_type
+            );
+        }
+
+        result
+    }
+
+    fn map_column(&self, col: &Column) -> ColumnMapping {
+        let type_mapping = self.map_type(&col.data_type, col.max_length, col.precision, col.scale);
+        ColumnMapping {
+            name: col.name.clone(),
+            target_type: type_mapping.target_type,
+            is_nullable: col.is_nullable,
+            warning: type_mapping.warning,
+        }
+    }
+}

--- a/crates/dmt-rs/src/ai/mod.rs
+++ b/crates/dmt-rs/src/ai/mod.rs
@@ -1,0 +1,18 @@
+//! AI-powered type mapping and database assistance.
+//!
+//! This module provides LLM-backed type mapping for cross-database migrations.
+//! When the static type mapper returns an unknown/fallback type, the AI mapper
+//! consults a configured LLM provider to determine the correct target type.
+//!
+//! Results are cached persistently to avoid repeated API calls.
+
+mod cache;
+mod config;
+mod mapper;
+mod prompt;
+mod provider;
+
+pub use cache::TypeCache;
+pub use config::{AiConfig, AiProvider, GlobalConfig};
+pub use mapper::AiTypeMapper;
+pub use provider::{AiProviderClient, create_provider};

--- a/crates/dmt-rs/src/ai/prompt.rs
+++ b/crates/dmt-rs/src/ai/prompt.rs
@@ -37,6 +37,12 @@ pub fn build_type_mapping_prompt(
 }
 
 /// Validate and clean an AI response to extract just the type name.
+///
+/// # Security
+///
+/// The returned string is used in DDL generation (CREATE TABLE statements).
+/// This function rejects responses containing SQL metacharacters to prevent
+/// injection attacks from malicious or confused AI responses.
 pub fn clean_type_response(response: &str) -> Option<String> {
     let cleaned = response
         .trim()
@@ -57,6 +63,29 @@ pub fn clean_type_response(response: &str) -> Option<String> {
 
     // Reject responses that look like explanations
     if cleaned.contains("The ") || cleaned.contains("This ") || cleaned.contains("You ") {
+        return None;
+    }
+
+    // Reject SQL metacharacters to prevent injection in DDL generation.
+    // Valid type names contain only: alphanumeric, spaces, parentheses, commas,
+    // brackets (for arrays like int[]), and periods (for schema-qualified types).
+    if cleaned.contains(';') || cleaned.contains("--") || cleaned.contains("/*") {
+        return None;
+    }
+
+    // Only allow characters that appear in valid type names
+    let valid = cleaned.chars().all(|c| {
+        c.is_alphanumeric()
+            || c == ' '
+            || c == '('
+            || c == ')'
+            || c == ','
+            || c == '['
+            || c == ']'
+            || c == '.'
+            || c == '_'
+    });
+    if !valid {
         return None;
     }
 
@@ -90,13 +119,34 @@ mod tests {
     }
 
     #[test]
-    fn test_clean_response() {
+    fn test_clean_response_valid() {
         assert_eq!(clean_type_response("text"), Some("text".to_string()));
         assert_eq!(clean_type_response("  text  "), Some("text".to_string()));
         assert_eq!(clean_type_response("`text`"), Some("text".to_string()));
         assert_eq!(clean_type_response("\"varchar(255)\""), Some("varchar(255)".to_string()));
+        assert_eq!(clean_type_response("numeric(18,2)"), Some("numeric(18,2)".to_string()));
+        assert_eq!(clean_type_response("integer[]"), Some("integer[]".to_string()));
+        assert_eq!(clean_type_response("double precision"), Some("double precision".to_string()));
+        assert_eq!(clean_type_response("character varying(100)"), Some("character varying(100)".to_string()));
+        assert_eq!(clean_type_response("bytea"), Some("bytea".to_string()));
+    }
+
+    #[test]
+    fn test_clean_response_rejects_invalid() {
         assert_eq!(clean_type_response(""), None);
         assert_eq!(clean_type_response("The best type is text"), None);
         assert_eq!(clean_type_response("line1\nline2"), None);
+    }
+
+    #[test]
+    fn test_clean_response_rejects_sql_injection() {
+        // Semicolons (statement termination)
+        assert_eq!(clean_type_response("TEXT); DROP TABLE users; --"), None);
+        // SQL comments
+        assert_eq!(clean_type_response("TEXT -- comment"), None);
+        assert_eq!(clean_type_response("TEXT /* block */"), None);
+        // Other dangerous characters
+        assert_eq!(clean_type_response("TEXT' OR '1'='1"), None);
+        assert_eq!(clean_type_response("TEXT; SELECT *"), None);
     }
 }

--- a/crates/dmt-rs/src/ai/prompt.rs
+++ b/crates/dmt-rs/src/ai/prompt.rs
@@ -1,0 +1,102 @@
+/// Build a type mapping prompt for the AI provider.
+pub fn build_type_mapping_prompt(
+    source_db: &str,
+    target_db: &str,
+    source_type: &str,
+    max_length: i32,
+    precision: i32,
+    scale: i32,
+) -> (String, String) {
+    let system = "You are a database type mapping expert. Your job is to map database column types \
+        from one database engine to another. Return ONLY the target type name with appropriate \
+        parameters (e.g., 'varchar(255)', 'numeric(18,2)', 'text'). No explanation, no markdown, \
+        no quotes — just the type name."
+        .to_string();
+
+    let mut user = format!(
+        "Map this source type to the best equivalent in the target database.\n\n\
+         Source database: {}\n\
+         Target database: {}\n\
+         Source type: {}",
+        source_db, target_db, source_type
+    );
+
+    if max_length > 0 {
+        user.push_str(&format!("\nMax length: {}", max_length));
+    }
+    if precision > 0 {
+        user.push_str(&format!("\nPrecision: {}", precision));
+    }
+    if scale > 0 {
+        user.push_str(&format!("\nScale: {}", scale));
+    }
+
+    user.push_str("\n\nTarget type:");
+
+    (system, user)
+}
+
+/// Validate and clean an AI response to extract just the type name.
+pub fn clean_type_response(response: &str) -> Option<String> {
+    let cleaned = response
+        .trim()
+        .trim_matches('`')
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim();
+
+    // Reject empty or multi-line responses
+    if cleaned.is_empty() || cleaned.contains('\n') {
+        return None;
+    }
+
+    // Reject responses that are too long (not a type name)
+    if cleaned.len() > 100 {
+        return None;
+    }
+
+    // Reject responses that look like explanations
+    if cleaned.contains("The ") || cleaned.contains("This ") || cleaned.contains("You ") {
+        return None;
+    }
+
+    Some(cleaned.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_prompt() {
+        let (system, user) = build_type_mapping_prompt(
+            "mssql", "postgres", "hierarchyid", 0, 0, 0,
+        );
+        assert!(system.contains("database type mapping expert"));
+        assert!(user.contains("hierarchyid"));
+        assert!(user.contains("mssql"));
+        assert!(user.contains("postgres"));
+        // No length/precision/scale lines when 0
+        assert!(!user.contains("Max length"));
+    }
+
+    #[test]
+    fn test_build_prompt_with_params() {
+        let (_, user) = build_type_mapping_prompt(
+            "mssql", "postgres", "decimal", 0, 18, 2,
+        );
+        assert!(user.contains("Precision: 18"));
+        assert!(user.contains("Scale: 2"));
+    }
+
+    #[test]
+    fn test_clean_response() {
+        assert_eq!(clean_type_response("text"), Some("text".to_string()));
+        assert_eq!(clean_type_response("  text  "), Some("text".to_string()));
+        assert_eq!(clean_type_response("`text`"), Some("text".to_string()));
+        assert_eq!(clean_type_response("\"varchar(255)\""), Some("varchar(255)".to_string()));
+        assert_eq!(clean_type_response(""), None);
+        assert_eq!(clean_type_response("The best type is text"), None);
+        assert_eq!(clean_type_response("line1\nline2"), None);
+    }
+}

--- a/crates/dmt-rs/src/ai/provider.rs
+++ b/crates/dmt-rs/src/ai/provider.rs
@@ -1,0 +1,264 @@
+use crate::ai::config::{AiConfig, AiProvider};
+use crate::ai::prompt::{build_type_mapping_prompt, clean_type_response};
+use crate::error::{MigrateError, Result};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+/// Trait for AI provider clients.
+#[async_trait]
+pub trait AiProviderClient: Send + Sync {
+    /// Map a source database type to a target type using AI.
+    async fn map_type(
+        &self,
+        source_db: &str,
+        target_db: &str,
+        source_type: &str,
+        max_length: i32,
+        precision: i32,
+        scale: i32,
+    ) -> Result<String>;
+}
+
+/// Create an AI provider client from config.
+pub fn create_provider(config: &AiConfig) -> Result<Box<dyn AiProviderClient>> {
+    let api_key = config.resolve_api_key();
+    let model = config.model_or_default();
+    let base_url = config.base_url_or_default();
+
+    match config.provider {
+        AiProvider::Anthropic => {
+            if api_key.is_empty() {
+                return Err(MigrateError::Config(
+                    "AI provider 'anthropic' requires an api_key (set ai.api_key or ANTHROPIC_API_KEY env var)".into()
+                ));
+            }
+            Ok(Box::new(AnthropicClient { api_key, model, base_url }))
+        }
+        AiProvider::OpenAI => {
+            if api_key.is_empty() {
+                return Err(MigrateError::Config(
+                    "AI provider 'openai' requires an api_key (set ai.api_key or OPENAI_API_KEY env var)".into()
+                ));
+            }
+            Ok(Box::new(OpenAiCompatibleClient { api_key, model, base_url }))
+        }
+        AiProvider::Ollama => {
+            Ok(Box::new(OpenAiCompatibleClient {
+                api_key: String::new(), // Ollama doesn't need auth
+                model,
+                base_url,
+            }))
+        }
+        AiProvider::LMStudio => {
+            Ok(Box::new(OpenAiCompatibleClient {
+                api_key: String::new(), // LM Studio doesn't need auth
+                model,
+                base_url,
+            }))
+        }
+    }
+}
+
+// --- Anthropic Client ---
+
+struct AnthropicClient {
+    api_key: String,
+    model: String,
+    base_url: String,
+}
+
+#[derive(Serialize)]
+struct AnthropicRequest {
+    model: String,
+    max_tokens: u32,
+    system: String,
+    messages: Vec<AnthropicMessage>,
+}
+
+#[derive(Serialize)]
+struct AnthropicMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct AnthropicResponse {
+    content: Vec<AnthropicContent>,
+}
+
+#[derive(Deserialize)]
+struct AnthropicContent {
+    text: String,
+}
+
+#[async_trait]
+impl AiProviderClient for AnthropicClient {
+    async fn map_type(
+        &self,
+        source_db: &str,
+        target_db: &str,
+        source_type: &str,
+        max_length: i32,
+        precision: i32,
+        scale: i32,
+    ) -> Result<String> {
+        let (system, user) = build_type_mapping_prompt(
+            source_db, target_db, source_type, max_length, precision, scale,
+        );
+
+        let request = AnthropicRequest {
+            model: self.model.clone(),
+            max_tokens: 100,
+            system,
+            messages: vec![AnthropicMessage {
+                role: "user".to_string(),
+                content: user,
+            }],
+        };
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/v1/messages", self.base_url);
+
+        debug!("AI type mapping request: {} {} -> {}", source_type, source_db, target_db);
+
+        let response = client
+            .post(&url)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("content-type", "application/json")
+            .json(&request)
+            .timeout(std::time::Duration::from_secs(30))
+            .send()
+            .await
+            .map_err(|e| MigrateError::Config(format!("AI API request failed: {}", e)))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(MigrateError::Config(format!(
+                "AI API returned {}: {}", status, body
+            )));
+        }
+
+        let body: AnthropicResponse = response
+            .json()
+            .await
+            .map_err(|e| MigrateError::Config(format!("AI API response parse error: {}", e)))?;
+
+        let raw = body.content.first()
+            .map(|c| c.text.clone())
+            .unwrap_or_default();
+
+        clean_type_response(&raw).ok_or_else(|| {
+            MigrateError::Config(format!(
+                "AI returned invalid type mapping for '{}': '{}'", source_type, raw
+            ))
+        })
+    }
+}
+
+// --- OpenAI-Compatible Client (OpenAI, Ollama, LM Studio) ---
+
+struct OpenAiCompatibleClient {
+    api_key: String,
+    model: String,
+    base_url: String,
+}
+
+#[derive(Serialize)]
+struct OpenAiRequest {
+    model: String,
+    max_tokens: u32,
+    messages: Vec<OpenAiMessage>,
+}
+
+#[derive(Serialize)]
+struct OpenAiMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct OpenAiResponse {
+    choices: Vec<OpenAiChoice>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiChoice {
+    message: OpenAiResponseMessage,
+}
+
+#[derive(Deserialize)]
+struct OpenAiResponseMessage {
+    content: String,
+}
+
+#[async_trait]
+impl AiProviderClient for OpenAiCompatibleClient {
+    async fn map_type(
+        &self,
+        source_db: &str,
+        target_db: &str,
+        source_type: &str,
+        max_length: i32,
+        precision: i32,
+        scale: i32,
+    ) -> Result<String> {
+        let (system, user) = build_type_mapping_prompt(
+            source_db, target_db, source_type, max_length, precision, scale,
+        );
+
+        let request = OpenAiRequest {
+            model: self.model.clone(),
+            max_tokens: 100,
+            messages: vec![
+                OpenAiMessage { role: "system".to_string(), content: system },
+                OpenAiMessage { role: "user".to_string(), content: user },
+            ],
+        };
+
+        let client = reqwest::Client::new();
+        let url = format!("{}/v1/chat/completions", self.base_url);
+
+        debug!("AI type mapping request: {} {} -> {}", source_type, source_db, target_db);
+
+        let mut req = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .json(&request)
+            .timeout(std::time::Duration::from_secs(30));
+
+        if !self.api_key.is_empty() {
+            req = req.header("authorization", format!("Bearer {}", self.api_key));
+        }
+
+        let response = req
+            .send()
+            .await
+            .map_err(|e| MigrateError::Config(format!("AI API request failed: {}", e)))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(MigrateError::Config(format!(
+                "AI API returned {}: {}", status, body
+            )));
+        }
+
+        let body: OpenAiResponse = response
+            .json()
+            .await
+            .map_err(|e| MigrateError::Config(format!("AI API response parse error: {}", e)))?;
+
+        let raw = body.choices.first()
+            .map(|c| c.message.content.clone())
+            .unwrap_or_default();
+
+        clean_type_response(&raw).ok_or_else(|| {
+            MigrateError::Config(format!(
+                "AI returned invalid type mapping for '{}': '{}'", source_type, raw
+            ))
+        })
+    }
+}

--- a/crates/dmt-rs/src/ai/provider.rs
+++ b/crates/dmt-rs/src/ai/provider.rs
@@ -33,7 +33,7 @@ pub fn create_provider(config: &AiConfig) -> Result<Box<dyn AiProviderClient>> {
                     "AI provider 'anthropic' requires an api_key (set ai.api_key or ANTHROPIC_API_KEY env var)".into()
                 ));
             }
-            Ok(Box::new(AnthropicClient { api_key, model, base_url }))
+            Ok(Box::new(AnthropicClient { api_key, model, base_url, http: reqwest::Client::new() }))
         }
         AiProvider::OpenAI => {
             if api_key.is_empty() {
@@ -41,20 +41,22 @@ pub fn create_provider(config: &AiConfig) -> Result<Box<dyn AiProviderClient>> {
                     "AI provider 'openai' requires an api_key (set ai.api_key or OPENAI_API_KEY env var)".into()
                 ));
             }
-            Ok(Box::new(OpenAiCompatibleClient { api_key, model, base_url }))
+            Ok(Box::new(OpenAiCompatibleClient { api_key, model, base_url, http: reqwest::Client::new() }))
         }
         AiProvider::Ollama => {
             Ok(Box::new(OpenAiCompatibleClient {
-                api_key: String::new(), // Ollama doesn't need auth
+                api_key: String::new(),
                 model,
                 base_url,
+                http: reqwest::Client::new(),
             }))
         }
         AiProvider::LMStudio => {
             Ok(Box::new(OpenAiCompatibleClient {
-                api_key: String::new(), // LM Studio doesn't need auth
+                api_key: String::new(),
                 model,
                 base_url,
+                http: reqwest::Client::new(),
             }))
         }
     }
@@ -66,6 +68,7 @@ struct AnthropicClient {
     api_key: String,
     model: String,
     base_url: String,
+    http: reqwest::Client,
 }
 
 #[derive(Serialize)]
@@ -117,12 +120,11 @@ impl AiProviderClient for AnthropicClient {
             }],
         };
 
-        let client = reqwest::Client::new();
         let url = format!("{}/v1/messages", self.base_url);
 
         debug!("AI type mapping request: {} {} -> {}", source_type, source_db, target_db);
 
-        let response = client
+        let response = self.http
             .post(&url)
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", "2023-06-01")
@@ -164,6 +166,7 @@ struct OpenAiCompatibleClient {
     api_key: String,
     model: String,
     base_url: String,
+    http: reqwest::Client,
 }
 
 #[derive(Serialize)]
@@ -218,12 +221,11 @@ impl AiProviderClient for OpenAiCompatibleClient {
             ],
         };
 
-        let client = reqwest::Client::new();
         let url = format!("{}/v1/chat/completions", self.base_url);
 
         debug!("AI type mapping request: {} {} -> {}", source_type, source_db, target_db);
 
-        let mut req = client
+        let mut req = self.http
             .post(&url)
             .header("content-type", "application/json")
             .json(&request)

--- a/crates/dmt-rs/src/core/catalog.rs
+++ b/crates/dmt-rs/src/core/catalog.rs
@@ -266,6 +266,22 @@ impl DriverCatalog {
             .collect()
     }
 
+    /// Wrap all registered type mappers with AI fallback.
+    ///
+    /// Each existing mapper becomes the inner (static) mapper of an `AiTypeMapper`.
+    /// Unknown types detected by the static mapper will be resolved via AI during
+    /// the warm-up phase.
+    #[cfg(feature = "ai")]
+    pub fn wrap_mappers_with_ai(&mut self, cache: Arc<crate::ai::TypeCache>) {
+        let keys: Vec<(String, String)> = self.type_mappers.keys().cloned().collect();
+        for key in keys {
+            if let Some(inner) = self.type_mappers.remove(&key) {
+                let ai_mapper = crate::ai::AiTypeMapper::new(inner, cache.clone());
+                self.type_mappers.insert(key, Arc::new(ai_mapper));
+            }
+        }
+    }
+
     // =========================================================================
     // Factory methods for creating readers and writers
     // =========================================================================

--- a/crates/dmt-rs/src/core/traits.rs
+++ b/crates/dmt-rs/src/core/traits.rs
@@ -374,6 +374,9 @@ pub struct TypeMapping {
     pub is_lossy: bool,
     /// Warning message for lossy mappings.
     pub warning: Option<String>,
+    /// Whether this is a fallback mapping for an unrecognized source type.
+    /// When true, AI type mapping will be attempted if configured.
+    pub is_fallback: bool,
 }
 
 impl TypeMapping {
@@ -383,6 +386,7 @@ impl TypeMapping {
             target_type: target_type.into(),
             is_lossy: false,
             warning: None,
+            is_fallback: false,
         }
     }
 
@@ -392,6 +396,18 @@ impl TypeMapping {
             target_type: target_type.into(),
             is_lossy: true,
             warning: Some(warning.into()),
+            is_fallback: false,
+        }
+    }
+
+    /// Create a fallback mapping for an unrecognized source type.
+    /// AI type mapping will be attempted for these if configured.
+    pub fn fallback(target_type: impl Into<String>, warning: impl Into<String>) -> Self {
+        Self {
+            target_type: target_type.into(),
+            is_lossy: true,
+            warning: Some(warning.into()),
+            is_fallback: true,
         }
     }
 }

--- a/crates/dmt-rs/src/dialect/typemap.rs
+++ b/crates/dmt-rs/src/dialect/typemap.rs
@@ -553,7 +553,7 @@ fn postgres_to_mssql(pg_type: &str, max_length: i32, precision: i32, scale: i32)
         "oid" => TypeMapping::lossless("bigint"),
 
         // Default fallback
-        _ => TypeMapping::lossy(
+        _ => TypeMapping::fallback(
             "nvarchar(max)",
             format!("Unknown PostgreSQL type '{}' stored as string.", pg_type),
         ),
@@ -656,7 +656,7 @@ fn mysql_to_postgres(mysql_type: &str, max_length: i32, precision: i32, scale: i
         ),
 
         // Default fallback
-        _ => TypeMapping::lossy(
+        _ => TypeMapping::fallback(
             "text",
             format!("Unknown MySQL type '{}' stored as text.", mysql_type),
         ),
@@ -818,7 +818,7 @@ fn postgres_to_mysql(pg_type: &str, max_length: i32, precision: i32, scale: i32)
         "oid" => TypeMapping::lossless("BIGINT UNSIGNED"),
 
         // Default fallback
-        _ => TypeMapping::lossy(
+        _ => TypeMapping::fallback(
             "LONGTEXT",
             format!("Unknown PostgreSQL type '{}' stored as text.", pg_type),
         ),
@@ -933,7 +933,7 @@ fn mysql_to_mssql(mysql_type: &str, max_length: i32, precision: i32, scale: i32)
         ),
 
         // Default fallback
-        _ => TypeMapping::lossy(
+        _ => TypeMapping::fallback(
             "nvarchar(max)",
             format!("Unknown MySQL type '{}' stored as string.", mysql_type),
         ),
@@ -1043,7 +1043,7 @@ pub fn mssql_to_mysql(
         ),
 
         // Default fallback
-        _ => TypeMapping::lossy(
+        _ => TypeMapping::fallback(
             "LONGTEXT",
             format!("Unknown MSSQL type '{}' stored as text.", mssql_type),
         ),
@@ -1349,7 +1349,7 @@ impl FromCanonical for MssqlFromCanonical {
             CanonicalType::Set(_) => TypeMapping::lossy("nvarchar(max)", "SET stored as string."),
 
             // Fallback
-            CanonicalType::Unknown(name) => TypeMapping::lossy(
+            CanonicalType::Unknown(name) => TypeMapping::fallback(
                 "nvarchar(max)",
                 format!("Unknown type '{}' stored as string.", name),
             ),
@@ -1480,6 +1480,7 @@ impl FromCanonical for PostgresFromCanonical {
                     target_type: format!("{}[]", inner_mapping.target_type),
                     is_lossy: inner_mapping.is_lossy,
                     warning: inner_mapping.warning,
+                    is_fallback: inner_mapping.is_fallback,
                 }
             }
 
@@ -1495,7 +1496,7 @@ impl FromCanonical for PostgresFromCanonical {
 
             // Fallback
             CanonicalType::Unknown(name) => {
-                TypeMapping::lossy("text", format!("Unknown type '{}' stored as text.", name))
+                TypeMapping::fallback("text", format!("Unknown type '{}' stored as text.", name))
             }
         }
     }
@@ -1998,7 +1999,7 @@ impl FromCanonical for MysqlFromCanonical {
             }
 
             // Fallback
-            CanonicalType::Unknown(name) => TypeMapping::lossy(
+            CanonicalType::Unknown(name) => TypeMapping::fallback(
                 "LONGTEXT",
                 format!("Unknown type '{}' stored as text.", name),
             ),

--- a/crates/dmt-rs/src/lib.rs
+++ b/crates/dmt-rs/src/lib.rs
@@ -41,6 +41,9 @@ pub mod state;
 pub mod target;
 pub mod transfer;
 
+#[cfg(feature = "ai")]
+pub mod ai;
+
 // Re-exports for convenient access
 pub use config::{
     Config, DatabaseType, MigrationConfig, SourceConfig, TableStats, TargetConfig, TargetMode,

--- a/crates/dmt-rs/src/orchestrator/mod.rs
+++ b/crates/dmt-rs/src/orchestrator/mod.rs
@@ -34,6 +34,12 @@ pub struct Orchestrator {
     catalog: DriverCatalog,
     progress_enabled: bool,
     progress_tx: Option<mpsc::Sender<ProgressUpdate>>,
+    /// AI type mapping cache (populated during warm-up).
+    #[cfg(feature = "ai")]
+    ai_cache: Option<std::sync::Arc<crate::ai::TypeCache>>,
+    /// AI provider configuration.
+    #[cfg(feature = "ai")]
+    ai_config: Option<crate::ai::AiConfig>,
 }
 
 /// Result of a migration run.
@@ -305,7 +311,26 @@ impl Orchestrator {
             catalog,
             progress_enabled: false,
             progress_tx: None,
+            #[cfg(feature = "ai")]
+            ai_cache: None,
+            #[cfg(feature = "ai")]
+            ai_config: None,
         })
+    }
+
+    /// Enable AI-powered type mapping using the provided configuration.
+    ///
+    /// This wraps all registered type mappers with an AI fallback layer.
+    /// Unknown types will be resolved via the configured LLM provider
+    /// during the warm-up phase (after schema extraction, before DDL generation).
+    #[cfg(feature = "ai")]
+    pub fn with_ai_config(mut self, ai_config: &crate::ai::AiConfig) -> Self {
+        let cache = std::sync::Arc::new(crate::ai::TypeCache::load(&ai_config.cache_path()));
+        self.catalog.wrap_mappers_with_ai(cache.clone());
+        self.ai_cache = Some(cache);
+        self.ai_config = Some(ai_config.clone());
+        info!("AI type mapping enabled (provider: {:?})", ai_config.provider);
+        self
     }
 
     /// Enable progress reporting to stderr as JSON lines.
@@ -540,6 +565,27 @@ impl Orchestrator {
         info!("Found {} tables to migrate", tables.len());
         let total_rows: i64 = tables.iter().map(|t| t.row_count).sum();
         self.emit_progress("schema_extracted", tables.len(), total_rows);
+
+        // AI warm-up: resolve unknown types via LLM before DDL generation
+        #[cfg(feature = "ai")]
+        if let (Some(ai_config), Some(ai_cache)) = (&self.ai_config, &self.ai_cache) {
+            let source_dialect = self.config.source.r#type.to_lowercase();
+            let target_dialect = self.config.target.r#type.to_lowercase();
+            if let Some(mapper) = self.catalog.get_mapper(&source_dialect, &target_dialect) {
+                // Create a temporary AiTypeMapper just for warm-up scanning
+                let ai_mapper = crate::ai::AiTypeMapper::new(mapper, ai_cache.clone());
+                match crate::ai::create_provider(ai_config) {
+                    Ok(provider) => {
+                        if let Err(e) = ai_mapper.warm_up(&tables, provider.as_ref()).await {
+                            warn!("AI warm-up failed, using static type mappings: {}", e);
+                        }
+                    }
+                    Err(e) => {
+                        warn!("Failed to create AI provider, using static type mappings: {}", e);
+                    }
+                }
+            }
+        }
 
         // Apply auto-tuning now that we know actual table sizes
         let table_stats: Vec<TableStats> = tables

--- a/crates/dmt-rs/src/orchestrator/mod.rs
+++ b/crates/dmt-rs/src/orchestrator/mod.rs
@@ -569,9 +569,11 @@ impl Orchestrator {
         // AI warm-up: resolve unknown types via LLM before DDL generation
         #[cfg(feature = "ai")]
         if let (Some(ai_config), Some(ai_cache)) = (&self.ai_config, &self.ai_cache) {
-            let source_dialect = self.config.source.r#type.to_lowercase();
-            let target_dialect = self.config.target.r#type.to_lowercase();
-            if let Some(mapper) = self.catalog.get_mapper(&source_dialect, &target_dialect) {
+            let source_dialect = DriverCatalog::normalize_db_type(&self.config.source.r#type)
+                .unwrap_or("unknown");
+            let target_dialect = DriverCatalog::normalize_db_type(&self.config.target.r#type)
+                .unwrap_or("unknown");
+            if let Some(mapper) = self.catalog.get_mapper(source_dialect, target_dialect) {
                 // Create a temporary AiTypeMapper just for warm-up scanning
                 let ai_mapper = crate::ai::AiTypeMapper::new(mapper, ai_cache.clone());
                 match crate::ai::create_provider(ai_config) {

--- a/docs/benchmark-go-vs-dmt-rs.md
+++ b/docs/benchmark-go-vs-dmt-rs.md
@@ -1,9 +1,8 @@
 # Go dmt vs dmt-rs — head-to-head benchmark
 
 Side-by-side comparison of [`dmt`](https://github.com/) (Go, v3.54.0-97-g4b174fa)
-and `dmt-rs` (this repo, commit `86e935f`) running the same SO2010 dataset
-through every cell of the 2 × 2 × 2 matrix
-**(direction × mode × engine)**.
+and `dmt-rs` (this repo) running the same SO2010 dataset through every cell
+of the 2 × 2 × 2 matrix **(direction × mode × engine)**.
 
 This doc replaces the stale numbers in `../BENCHMARKS.md` (January 2026).
 
@@ -11,21 +10,20 @@ This doc replaces the stale numbers in `../BENCHMARKS.md` (January 2026).
 
 | Setting | Value |
 |---|---|
-| Date | 2026-04-11 (cells 1-8), 2026-04-14 (cells 4, 8 rerun) |
+| Date | 2026-04-14 (full re-sweep) |
 | Host | Apple M5 Pro, 24 GB RAM |
-| Docker Desktop VM | 8 GiB, 2-container layout (one MSSQL + one PG) |
-| MSSQL | SQL Server 2022 under Rosetta 2 emulation, `max server memory = 4096 MB` |
-| PostgreSQL | 16 Alpine native arm64, aggressive write tuning baked into image |
+| Docker Desktop VM | 3-container layout (one MSSQL, two PG) |
+| MSSQL | SQL Server 2022 under Rosetta 2 emulation |
+| PostgreSQL | 16 Alpine native arm64 |
 | Dataset | StackOverflow2010 (Brent Ozar), **19,310,703 rows** across 9 tables |
-| Go binary | `dmt v3.54.0-97-g4b174fa` |
-| dmt-rs binary | release build, commit `86e935f` (cells 1-8); commit `78ceb0f` (cells 4, 8 rerun — includes PR #100 bb8 pool fix and PR #101 oversized string fix) |
-| Methodology | Single-instance source/target on same container per engine; warm cache; targets reset between runs; upsert runs use a populated target (populated via Go in the discarded preload step) |
+| Go binary | `dmt v3.54.0-97-g4b174fa` (numbers from 2026-04-11 session) |
+| dmt-rs binary | release build, commit `93357f7` (includes PRs #100, #101, #102) |
+| Methodology | Warm cache; targets reset between runs; upsert runs use a pre-populated target (populated via dmt-rs `drop_recreate` in the preceding cell); indexes/FKs/checks disabled in all configs |
 
-For the `pg → mssql` and `mssql → pg` cells the source and target are on
-**different** containers (the only setup possible). For the `pg → pg` and
-`mssql → mssql` cells, source and target are different *databases* on the
-same container. This is the cleanest budget-respecting layout for an 8 GiB
-Docker VM and matches §4 of the benchmark playbook.
+For `pg → mssql` and `mssql → pg` the source and target are on **different**
+containers. For `pg → pg`, source (`pg-bench:5432`) and target (`pg-target:5434`)
+are separate containers. For `mssql → mssql`, source (`StackOverflow2010`) and
+target (`dmt_test_target`) are different databases on the same container.
 
 ## Results
 
@@ -34,48 +32,88 @@ disabled in all configs):
 
 | # | Direction | Mode | Go | dmt-rs | Winner |
 |---|---|---|---:|---:|---|
-| 1 | mssql → pg | drop_recreate | 42s | 44.7s | ~tie |
-| 2 | mssql → pg | upsert | 33s | 47.3s | Go 1.43× |
-| 3 | pg → mssql | drop_recreate | 60s | 132.2s | Go 2.20× |
-| 4 | pg → mssql | upsert | 120s | **108.2s** | **dmt-rs 1.11×** |
-| 5 | pg → pg | drop_recreate | 29s | **20s** | **dmt-rs 1.45×** |
-| 6 | pg → pg | upsert | 18s | 66s | Go 3.67× |
-| 7 | mssql → mssql | drop_recreate | 85s | 112s | Go 1.32× |
-| 8 | mssql → mssql | upsert | 142s | **104.4s** | **dmt-rs 1.36×** |
-
-Cells 1–3, 5–7 were measured on 2026-04-11. Cells 4 and 8 were rerun on
-2026-04-14 after PR #100 (cap `parallel_writers` to 1 for MSSQL upsert)
-and PR #101 (oversized string detection in upsert staging) landed — both
-previously FAILED due to dmt-rs#97.
+| 1 | mssql → pg | drop_recreate | 42s | **36.3s** | **dmt-rs 1.16×** |
+| 2 | mssql → pg | upsert | 33s | 49.7s | Go 1.51× |
+| 3 | pg → mssql | drop_recreate | 60s | 77.8s | Go 1.30× |
+| 4 | pg → mssql | upsert | 120s | **109.7s** | **dmt-rs 1.09×** |
+| 5 | pg → pg | drop_recreate | 29s | **21.3s** | **dmt-rs 1.36×** |
+| 6 | pg → pg | upsert | 18s | 34.4s | Go 1.91× |
+| 7 | mssql → mssql | drop_recreate | 85s | 104.1s | Go 1.22× |
+| 8 | mssql → mssql | upsert | 142s | **92.2s** | **dmt-rs 1.54×** |
 
 ### Throughput view (rows/sec, end-to-end)
 
 | Direction | Mode | Go | dmt-rs |
 |---|---|---:|---:|
-| mssql → pg | drop_recreate | 460k | 432k |
-| mssql → pg | upsert (pre-pop) | 585k | 408k |
-| pg → mssql | drop_recreate | 322k | 146k |
-| pg → mssql | upsert (pre-pop) | 161k | 178k |
-| pg → pg | drop_recreate | 666k | **966k** |
-| pg → pg | upsert (pre-pop) | 1.07M | 293k |
-| mssql → mssql | drop_recreate | 227k | 173k |
-| mssql → mssql | upsert (pre-pop) | 136k | 185k |
+| mssql → pg | drop_recreate | 460k | **533k** |
+| mssql → pg | upsert (pre-pop) | 585k | 388k |
+| pg → mssql | drop_recreate | 322k | 248k |
+| pg → mssql | upsert (pre-pop) | 161k | 176k |
+| pg → pg | drop_recreate | 666k | **905k** |
+| pg → pg | upsert (pre-pop) | 1.07M | 561k |
+| mssql → mssql | drop_recreate | 227k | 186k |
+| mssql → mssql | upsert (pre-pop) | 136k | **209k** |
 
-## dmt-rs Phase F failure mode (historical — fixed by PRs #100 + #102)
+## Patterns
 
-> **Update 2026-04-14:** Both upsert-to-MSSQL cells now pass. Two PRs
-> addressed the issue:
->
-> - **PR #100** capped `parallel_writers` to 1 for MSSQL upsert — a
->   correctness optimization since `MERGE WITH (TABLOCK)` serializes
->   writers at the DB level anyway, so extra writers just waste pool
->   connections.
-> - **PR #102** fixed the underlying orchestrator bug (#97): per-table
->   `CancellationToken`s are now shared across partitions, so a writer
->   failure in any partition cancels siblings immediately instead of
->   cascading into pool exhaustion and data loss.
+1. **dmt-rs wins 4 cells**: `mssql → pg` drop_recreate (1.16×),
+   `pg → pg` drop_recreate (1.36×), `pg → mssql` upsert (1.09×), and
+   `mssql → mssql` upsert (1.54×). The common thread: binary COPY
+   source reads and/or the MSSQL MERGE upsert path with per-chunk
+   staging.
 
-The original `mssql → mssql` upsert run (pre-fix) failed in 78s with `rc=2`:
+2. **Go wins 4 cells**: `mssql → pg` upsert (1.51×), `pg → mssql`
+   drop_recreate (1.30×), `pg → pg` upsert (1.91×), and `mssql → mssql`
+   drop_recreate (1.22×).
+
+3. **MSSQL `drop_recreate` writes** (`pg → mssql`, `mssql → mssql`) are
+   dmt-rs's loss zone. The forked tiberius batched-INSERT path is the
+   ceiling. Confirmed across two source engines — this isn't a config
+   artifact.
+
+4. **PG upsert is 1.91× slower in dmt-rs** (down from 3.67× in the
+   previous run). Go's `pg → pg` upsert is *faster* than its `pg → pg`
+   `drop_recreate` (18s vs 29s) because pre-populated targets allow `IS
+   DISTINCT FROM` change detection to skip unchanged rows. dmt-rs's
+   upsert codepath does not exploit this yet.
+
+## What this means
+
+dmt-rs **wins 4 cells** and **loses 4** — an even split. The scorecard
+improved from 1-1-6 (April 11 baseline) to 3-1-4 (after PRs #100–#102)
+to **4-0-4** (this re-sweep on the same commit).
+
+The improvement on this sweep vs the April 11 numbers is partly from the
+#102 cancellation-token fix reducing overhead, and partly from a
+different container layout (3 containers instead of 2, giving MSSQL more
+breathing room).
+
+Two known issues account for the remaining lost ground:
+
+1. **tiberius batched INSERT throughput** — caps `drop_recreate`
+   directions targeting MSSQL. Replacing or supplementing tiberius is
+   tracked in `mssql-client-spike.md`.
+2. **dmt-rs upsert codepath is slow on PG → PG.** The
+   `INSERT … ON CONFLICT DO UPDATE` chunking does not benefit from the
+   `IS DISTINCT FROM` skip-unchanged optimization that Go's upsert path
+   uses. This is independent of issue #1 and worth a separate
+   investigation.
+
+## Historical: dmt-rs#97 failure mode (fixed by PRs #100 + #102)
+
+Both upsert-to-MSSQL cells previously FAILED due to dmt-rs#97. Two PRs
+addressed the issue:
+
+- **PR #100** capped `parallel_writers` to 1 for MSSQL upsert — a
+  correctness optimization since `MERGE WITH (TABLOCK)` serializes
+  writers at the DB level anyway, so extra writers just waste pool
+  connections.
+- **PR #102** fixed the underlying orchestrator bug (#97): per-table
+  `CancellationToken`s are now shared across partitions, so a writer
+  failure in any partition cancels siblings immediately instead of
+  cascading into pool exhaustion and data loss.
+
+The original failure mode (before fixes):
 
 ```
 ERROR  Bulk load data was expected but not sent. The batch will be terminated. code=4022
@@ -83,129 +121,26 @@ ERROR  dbo.Users: failed - Transfer failed for table Users:
        Writer 1 failed: Pool error: Timed out in bb8
 ```
 
-What was notable:
-
-- The error appeared on `dbo.Users` first.
-- **Other tables continued and reported success** (Comments, Votes both
-  finished after the error). The orchestrator did not propagate the
-  writer-pool failure to cancel sibling table transfers.
+- Sibling tables continued after the error — the orchestrator did not
+  propagate the writer-pool failure.
 - Final tally: `Migration failed: 9 tables, 1,263,563 / 19,310,703 rows in 78.3s`.
-- The process exited cleanly with `rc=2` instead of hanging.
-
-The hang vs. clean-exit asymmetry suggested `#97` has multiple branches
-depending on which writer fails first and which sibling tables are still
-alive. Filed as additional context on dmt-rs#97.
-
-## Patterns
-
-1. **dmt-rs wins three cells**: `pg → pg` `drop_recreate` (1.45×),
-   `pg → mssql` upsert (1.11×), and `mssql → mssql` upsert (1.36×).
-   The upsert wins are new as of 2026-04-14 after PR #100 capped
-   `parallel_writers` to 1 for MSSQL upsert — a correctness
-   optimization since `MERGE WITH (TABLOCK)` serializes writers at
-   the DB level anyway.
-
-2. **dmt-rs ties on `mssql → pg` `drop_recreate`**. Same reason: binary
-   COPY into the target carries the workload, source overhead is minor.
-
-3. **MSSQL `drop_recreate` writes** (`pg → mssql`, `mssql → mssql`) are
-   dmt-rs's loss zone. The forked tiberius batched-INSERT path is the
-   ceiling. Confirmed across two source engines — this isn't a config
-   artifact.
-
-4. **`pg → pg` upsert is 3.67× slower in dmt-rs** even with MSSQL out of
-   the picture. Go's `pg → pg` upsert is *faster* than its `pg → pg`
-   `drop_recreate` (18s vs 29s) because pre-populated targets allow `IS
-   DISTINCT FROM` change detection to skip unchanged rows. dmt-rs's
-   upsert codepath does not exploit this.
-   **Still worth investigating** — the MSSQL bottleneck is not the
-   only thing capping dmt-rs's upsert performance; the
-   `INSERT … ON CONFLICT DO UPDATE` chunking codepath itself is slow
-   independently of the tiberius bottleneck.
-
-## Per-table detail (dmt-rs only — Go binary doesn't log per-table timings to stderr)
-
-`pg → pg` `drop_recreate` (the dmt-rs win):
-
-| Table | Rows | Duration | Throughput |
-|---|---:|---:|---:|
-| public.votes | 10,143,364 | 5.0s | 2.02M rows/s |
-| public.comments | 3,875,183 | 5.1s | 760k rows/s |
-| public.posts | 3,729,195 | 15.4s | 242k rows/s |
-
-(End-to-end including finalization: 19.4s for 19.3M rows = **993k rows/s**.)
-
-`mssql → mssql` `drop_recreate`:
-
-| Table | Rows | Duration | Throughput |
-|---|---:|---:|---:|
-| dbo.Posts | 3,729,195 (3 partitions) | up to 94.5s | 13–15k rows/s |
-| dbo.Votes | 10,143,364 (3 partitions) | up to 32.6s | 104–129k rows/s |
-| dbo.Comments | 3,875,183 (3 partitions) | up to 12.6s | 102–107k rows/s |
-
-(End-to-end: 111.8s for 19.3M rows = **173k rows/s**.) dbo.Posts is the
-choke point here — the LOB-heavy table dominates wall time.
-
-`pg → pg` upsert (pre-populated, the surprise loss):
-
-| Table | Rows | Duration | Throughput |
-|---|---:|---:|---:|
-| public.votes | 10,143,364 | 60.1s | 169k rows/s |
-| public.posts | 3,729,195 | 66.1s | 56k rows/s |
-| public.comments | 3,875,183 | 43.4s | 89k rows/s |
-
-(End-to-end: 66.3s for 19.3M rows = **291k rows/s**, vs Go at ~1.07M rows/s.)
-The per-table throughputs above are 7×–11× lower than the same tables in
-`drop_recreate` mode. The upsert codepath is the bottleneck, not the
-underlying `COPY` plumbing.
-
-## What this means
-
-dmt-rs **wins 3 cells** (pg→pg drop_recreate, pg→mssql upsert,
-mssql→mssql upsert), **ties 1** (mssql→pg drop_recreate), and **loses
-4** (the remaining cells). The scorecard improved from 1-1-6 to 3-1-4
-after PR #100 unblocked the two upsert-to-MSSQL cells.
-
-Two known issues account for the remaining lost ground:
-
-1. **tiberius batched INSERT throughput** — caps `drop_recreate`
-   directions targeting MSSQL at roughly half of Go. Replacing or
-   supplementing tiberius is tracked in `mssql-client-spike.md`.
-2. **dmt-rs upsert codepath is slow on PG → PG.** The
-   `INSERT … ON CONFLICT DO UPDATE` chunking does not benefit from the
-   `IS DISTINCT FROM` skip-unchanged optimization that Go's upsert path
-   uses. This is independent of issue #1 and worth a separate
-   investigation.
-
-One issue has been **fully fixed**:
-
-3. **dmt-rs#97 — orchestrator deadlock / data-loss on writer failure**
-   — The orchestrator now shares per-table `CancellationToken`s across
-   partitions, so a writer failure in any partition immediately cancels
-   sibling partitions' dispatchers. Previously, sibling partitions
-   continued running unaware, cascading into pool exhaustion and data
-   loss. The `parallel_writers` cap to 1 for MSSQL upsert (PR #100) is
-   retained as a correctness optimization (TABLOCK serializes at the DB
-   level), not a workaround.
 
 ## Reproduction
 
 The exact configs and sweep script live in `/tmp` and are cleaned up on
 host reboot. The procedure is documented in `benchmark-playbook.md` §6;
-this comparison uses the same configs but with a single-instance pg-pg
-and single-instance mssql-mssql target layout, plus parallel YAMLs for
-the Go binary that match the dmt-rs configs key-for-key.
+this comparison uses the same configs but with a 3-container layout
+(mssql-bench, pg-bench, pg-target).
 
 To reproduce on a fresh host:
 
 1. Build the Go binary at `/Users/johndauphine/repos/dmt`
    (`go build -o dmt ./cmd/dmt`).
 2. Build the Rust binary (`cargo build --release`).
-3. Stand up the 2-container Docker layout from playbook §4 (one MSSQL,
-   one PG).
+3. Stand up the 3-container Docker layout (one MSSQL, two PG).
 4. Generate matching YAML pairs (Go and dmt-rs) for each of the 8 cells.
-5. Reset target between every measured run; populate via Go for upsert
-   measured runs to avoid dmt-rs state contamination.
+5. Reset target between every measured run; populate via `drop_recreate`
+   for upsert measured runs.
 6. All 8 cells should complete without intervention (dmt-rs#97 is fixed).
 
 ## Related docs
@@ -217,6 +152,6 @@ To reproduce on a fresh host:
 - [`mssql-client-spike.md`](mssql-client-spike.md) — alternative MSSQL
   driver evaluation
 - [dmt-rs#97](https://github.com/) — orchestrator deadlock / silent
-  data-loss on writer failure (the blocker for upsert-to-MSSQL)
+  data-loss on writer failure (fixed by PRs #100 + #102)
 - `../BENCHMARKS.md` — older Go vs Rust comparison numbers (January 2026,
   superseded by this doc)

--- a/docs/benchmark-go-vs-dmt-rs.md
+++ b/docs/benchmark-go-vs-dmt-rs.md
@@ -1,6 +1,6 @@
 # Go dmt vs dmt-rs — head-to-head benchmark
 
-Side-by-side comparison of [`dmt`](https://github.com/) (Go, v3.54.0-97-g4b174fa)
+Side-by-side comparison of [`dmt`](https://github.com/) (Go, v3.54.0)
 and `dmt-rs` (this repo) running the same SO2010 dataset through every cell
 of the 2 × 2 × 2 matrix **(direction × mode × engine)**.
 
@@ -10,15 +10,15 @@ This doc replaces the stale numbers in `../BENCHMARKS.md` (January 2026).
 
 | Setting | Value |
 |---|---|
-| Date | 2026-04-14 (full re-sweep) |
+| Date | 2026-04-14 |
 | Host | Apple M5 Pro, 24 GB RAM |
-| Docker Desktop VM | 3-container layout (one MSSQL, two PG) |
-| MSSQL | SQL Server 2022 under Rosetta 2 emulation |
-| PostgreSQL | 16 Alpine native arm64 |
+| Docker Desktop VM | 3-container layout (mssql-bench, pg-bench, pg-target) |
+| MSSQL | SQL Server 2022 under Rosetta 2 emulation (mssql-bench:1433) |
+| PostgreSQL | 16 Alpine native arm64 (pg-bench:5432, pg-target:5434) |
 | Dataset | StackOverflow2010 (Brent Ozar), **19,310,703 rows** across 9 tables |
-| Go binary | `dmt v3.54.0-97-g4b174fa` (numbers from 2026-04-11 session) |
+| Go binary | `dmt v3.54.0` |
 | dmt-rs binary | release build, commit `93357f7` (includes PRs #100, #101, #102) |
-| Methodology | Warm cache; targets reset between runs; upsert runs use a pre-populated target (populated via dmt-rs `drop_recreate` in the preceding cell); indexes/FKs/checks disabled in all configs |
+| Methodology | Both binaries run back-to-back on the same session with warm caches; targets reset between runs; upsert runs use a pre-populated target (populated via the preceding `drop_recreate` cell); indexes/FKs/checks disabled in all configs |
 
 For `pg → mssql` and `mssql → pg` the source and target are on **different**
 containers. For `pg → pg`, source (`pg-bench:5432`) and target (`pg-target:5434`)
@@ -32,72 +32,86 @@ disabled in all configs):
 
 | # | Direction | Mode | Go | dmt-rs | Winner |
 |---|---|---|---:|---:|---|
-| 1 | mssql → pg | drop_recreate | 42s | **36.3s** | **dmt-rs 1.16×** |
-| 2 | mssql → pg | upsert | 33s | 49.7s | Go 1.51× |
-| 3 | pg → mssql | drop_recreate | 60s | 77.8s | Go 1.30× |
-| 4 | pg → mssql | upsert | 120s | **109.7s** | **dmt-rs 1.09×** |
+| 1 | mssql → pg | drop_recreate | **28s** | 36.3s | Go 1.30× |
+| 2 | mssql → pg | upsert | **22s** | 49.7s | Go 2.26× |
+| 3 | pg → mssql | drop_recreate | **46s** | 77.8s | Go 1.69× |
+| 4 | pg → mssql | upsert | **85s** | 109.7s | Go 1.29× |
 | 5 | pg → pg | drop_recreate | 29s | **21.3s** | **dmt-rs 1.36×** |
-| 6 | pg → pg | upsert | 18s | 34.4s | Go 1.91× |
-| 7 | mssql → mssql | drop_recreate | 85s | 104.1s | Go 1.22× |
-| 8 | mssql → mssql | upsert | 142s | **92.2s** | **dmt-rs 1.54×** |
+| 6 | pg → pg | upsert | **24s** | 34.4s | Go 1.43× |
+| 7 | mssql → mssql | drop_recreate | **60s** | 104.1s | Go 1.73× |
+| 8 | mssql → mssql | upsert | 95s | **92.2s** | **~tie (dmt-rs 1.03×)** |
 
 ### Throughput view (rows/sec, end-to-end)
 
 | Direction | Mode | Go | dmt-rs |
 |---|---|---:|---:|
-| mssql → pg | drop_recreate | 460k | **533k** |
-| mssql → pg | upsert (pre-pop) | 585k | 388k |
-| pg → mssql | drop_recreate | 322k | 248k |
-| pg → mssql | upsert (pre-pop) | 161k | 176k |
-| pg → pg | drop_recreate | 666k | **905k** |
-| pg → pg | upsert (pre-pop) | 1.07M | 561k |
-| mssql → mssql | drop_recreate | 227k | 186k |
-| mssql → mssql | upsert (pre-pop) | 136k | **209k** |
+| mssql → pg | drop_recreate | **678k** | 533k |
+| mssql → pg | upsert (pre-pop) | **872k** | 388k |
+| pg → mssql | drop_recreate | **419k** | 248k |
+| pg → mssql | upsert (pre-pop) | **228k** | 176k |
+| pg → pg | drop_recreate | 656k | **905k** |
+| pg → pg | upsert (pre-pop) | **815k** | 561k |
+| mssql → mssql | drop_recreate | **324k** | 186k |
+| mssql → mssql | upsert (pre-pop) | 204k | **209k** |
 
 ## Patterns
 
-1. **dmt-rs wins 4 cells**: `mssql → pg` drop_recreate (1.16×),
-   `pg → pg` drop_recreate (1.36×), `pg → mssql` upsert (1.09×), and
-   `mssql → mssql` upsert (1.54×). The common thread: binary COPY
-   source reads and/or the MSSQL MERGE upsert path with per-chunk
-   staging.
+1. **dmt-rs wins 1 cell clearly**: `pg → pg` drop_recreate (1.36×).
+   Pure binary COPY on both ends, no MSSQL involvement. This is the
+   configuration where dmt-rs's architecture shines.
 
-2. **Go wins 4 cells**: `mssql → pg` upsert (1.51×), `pg → mssql`
-   drop_recreate (1.30×), `pg → pg` upsert (1.91×), and `mssql → mssql`
-   drop_recreate (1.22×).
+2. **dmt-rs ties on `mssql → mssql` upsert** (92.2s vs 95s). The MERGE
+   WITH (TABLOCK) per-chunk staging path is competitive with Go's
+   approach.
 
-3. **MSSQL `drop_recreate` writes** (`pg → mssql`, `mssql → mssql`) are
-   dmt-rs's loss zone. The forked tiberius batched-INSERT path is the
-   ceiling. Confirmed across two source engines — this isn't a config
-   artifact.
+3. **Go wins 6 cells**, with the largest gaps on MSSQL-target directions.
+   The forked tiberius batched-INSERT path is the bottleneck for
+   `drop_recreate` (cells 3, 7), and Go's upsert implementation is
+   significantly faster across all directions (cells 2, 4, 6).
 
-4. **PG upsert is 1.91× slower in dmt-rs** (down from 3.67× in the
-   previous run). Go's `pg → pg` upsert is *faster* than its `pg → pg`
-   `drop_recreate` (18s vs 29s) because pre-populated targets allow `IS
-   DISTINCT FROM` change detection to skip unchanged rows. dmt-rs's
-   upsert codepath does not exploit this yet.
+4. **Every upsert cell is a Go win or tie.** Go's upsert path benefits
+   from `IS DISTINCT FROM` skip-unchanged optimization on PG targets,
+   and a more efficient MERGE implementation on MSSQL targets. dmt-rs's
+   `INSERT … ON CONFLICT DO UPDATE` chunking does not exploit
+   skip-unchanged yet.
+
+5. **The MSSQL write bottleneck is larger than previously measured.**
+   On the old 2-container/8 GiB layout, MSSQL was memory-starved,
+   making both Go and dmt-rs slower. The 3-container layout gives MSSQL
+   more headroom, which benefits Go more than dmt-rs — suggesting Go's
+   driver utilizes MSSQL's buffer pool more efficiently.
 
 ## What this means
 
-dmt-rs **wins 4 cells** and **loses 4** — an even split. The scorecard
-improved from 1-1-6 (April 11 baseline) to 3-1-4 (after PRs #100–#102)
-to **4-0-4** (this re-sweep on the same commit).
+dmt-rs **wins 1 cell**, **ties 1**, and **loses 6**. The only clear win
+is `pg → pg` drop_recreate, where binary COPY on both ends bypasses
+all the MSSQL bottlenecks.
 
-The improvement on this sweep vs the April 11 numbers is partly from the
-#102 cancellation-token fix reducing overhead, and partly from a
-different container layout (3 containers instead of 2, giving MSSQL more
-breathing room).
-
-Two known issues account for the remaining lost ground:
+Three issues account for the lost ground:
 
 1. **tiberius batched INSERT throughput** — caps `drop_recreate`
-   directions targeting MSSQL. Replacing or supplementing tiberius is
-   tracked in `mssql-client-spike.md`.
-2. **dmt-rs upsert codepath is slow on PG → PG.** The
+   directions targeting MSSQL at roughly half of Go. The gap is 1.69×
+   on pg→mssql and 1.73× on mssql→mssql. Replacing or supplementing
+   tiberius is tracked in `mssql-client-spike.md`.
+
+2. **dmt-rs upsert codepath is slow on PG targets.** The
    `INSERT … ON CONFLICT DO UPDATE` chunking does not benefit from the
    `IS DISTINCT FROM` skip-unchanged optimization that Go's upsert path
-   uses. This is independent of issue #1 and worth a separate
-   investigation.
+   uses. This costs 1.43× on pg→pg and 2.26× on mssql→pg.
+
+3. **MSSQL source reads are slower in dmt-rs.** Even on mssql→pg
+   drop_recreate (where the PG target is fast), Go is 1.30× faster.
+   This suggests tiberius source-side query streaming is also slower
+   than Go's MSSQL driver.
+
+## Note on previous numbers
+
+Earlier versions of this doc reported a 4-0-4 scorecard based on
+comparing Go numbers from a 2-container/8 GiB layout (April 11) against
+dmt-rs numbers from a 3-container layout (April 14). That comparison was
+misleading — the infrastructure change benefited both binaries, but Go
+improved more. This doc now uses same-session, same-infrastructure
+numbers for a fair comparison.
 
 ## Historical: dmt-rs#97 failure mode (fixed by PRs #100 + #102)
 
@@ -113,24 +127,11 @@ addressed the issue:
   failure in any partition cancels siblings immediately instead of
   cascading into pool exhaustion and data loss.
 
-The original failure mode (before fixes):
-
-```
-ERROR  Bulk load data was expected but not sent. The batch will be terminated. code=4022
-ERROR  dbo.Users: failed - Transfer failed for table Users:
-       Writer 1 failed: Pool error: Timed out in bb8
-```
-
-- Sibling tables continued after the error — the orchestrator did not
-  propagate the writer-pool failure.
-- Final tally: `Migration failed: 9 tables, 1,263,563 / 19,310,703 rows in 78.3s`.
-
 ## Reproduction
 
-The exact configs and sweep script live in `/tmp` and are cleaned up on
-host reboot. The procedure is documented in `benchmark-playbook.md` §6;
-this comparison uses the same configs but with a 3-container layout
-(mssql-bench, pg-bench, pg-target).
+The exact configs live in `/tmp/go-*.yaml` and `/tmp/dmt-rs-*.yaml` and
+are cleaned up on host reboot. The procedure is documented in
+`benchmark-playbook.md` §6.
 
 To reproduce on a fresh host:
 
@@ -138,7 +139,7 @@ To reproduce on a fresh host:
    (`go build -o dmt ./cmd/dmt`).
 2. Build the Rust binary (`cargo build --release`).
 3. Stand up the 3-container Docker layout (one MSSQL, two PG).
-4. Generate matching YAML pairs (Go and dmt-rs) for each of the 8 cells.
+4. Run dmt-rs sweep, then Go sweep (or vice versa) in the same session.
 5. Reset target between every measured run; populate via `drop_recreate`
    for upsert measured runs.
 6. All 8 cells should complete without intervention (dmt-rs#97 is fixed).


### PR DESCRIPTION
## Summary

- Add LLM-backed type mapping for unknown/exotic database types (e.g., MSSQL `hierarchyid` → PG `bytea`)
- Feature-gated behind `--features ai` — zero impact on default binary
- Supports 4 providers: Anthropic (default), OpenAI, Ollama, LM Studio
- Persistent JSON cache at `~/.dmt-rs/type-cache.json` — each type is resolved once, never again
- Global config at `~/.dmt-rs/dmt-rs-config.yaml` with `--global-config` CLI flag to override
- Secure file permissions: directory `700`, config/cache files `600`, warns if overly permissive
- Graceful degradation: AI failure → warn + static fallback, never blocks migration

## How it works

```
Schema extraction → scan for unknown types → batch AI warm-up → cache results → DDL uses cached types
```

Static mapper tries first. Only unknown/fallback types trigger AI. Results are cached persistently so subsequent runs are instant.

## Config

```yaml
# ~/.dmt-rs/dmt-rs-config.yaml
ai:
  api_key: sk-ant-...  # or ${env:ANTHROPIC_API_KEY}
  provider: anthropic   # anthropic | openai | ollama | lmstudio
  model: claude-haiku-4-5-20251001
```

## Test plan

- [x] `cargo build --release` — non-AI build clean
- [x] `cargo build --release --features ai` — AI build clean
- [x] `cargo test` + `cargo test --features ai` — all pass
- [x] End-to-end: MSSQL `hierarchyid` → PG `bytea` via Anthropic Claude Haiku (644ms)
- [x] Cache persisted to disk and reloaded on next run
- [x] File permissions verified: `700` dir, `600` files
- [x] Warns on overly permissive config file

🤖 Generated with [Claude Code](https://claude.com/claude-code)