### PR TITLE
Fix incremental sync watermark and resume handling

### DIFF
--- a/crates/dmt-rs/src/drivers/postgres/reader.rs
+++ b/crates/dmt-rs/src/drivers/postgres/reader.rs
@@ -243,6 +243,9 @@ impl PostgresReader {
         pk_col: Option<&str>,
         min_pk: Option<i64>,
         max_pk: Option<i64>,
+        resume_from_pk: Option<i64>,
+        date_filter_column: Option<&str>,
+        date_filter_timestamp: Option<String>,
         tx: mpsc::Sender<Vec<Vec<SqlValue<'static>>>>,
         batch_size: usize,
     ) -> Result<i64> {
@@ -252,7 +255,17 @@ impl PostgresReader {
             .await
             .map_err(|e| MigrateError::pool(e, "getting connection for copy_rows_binary"))?;
 
-        let query = build_copy_query(schema, table, columns, pk_col, min_pk, max_pk);
+        let query = build_copy_query(
+            schema,
+            table,
+            columns,
+            pk_col,
+            min_pk,
+            max_pk,
+            resume_from_pk,
+            date_filter_column,
+            date_filter_timestamp.as_deref(),
+        );
         debug!("COPY query: {}", query);
 
         let copy_stream = client.copy_out(&query).await.map_err(|e| {
@@ -319,6 +332,9 @@ impl PostgresReader {
         pk_col: Option<&str>,
         min_pk: Option<i64>,
         max_pk: Option<i64>,
+        resume_from_pk: Option<i64>,
+        date_filter_column: Option<&str>,
+        date_filter_timestamp: Option<String>,
         tx: mpsc::Sender<Vec<Vec<TargetSqlValue>>>,
         batch_size: usize,
     ) -> Result<i64> {
@@ -328,7 +344,17 @@ impl PostgresReader {
             .await
             .map_err(|e| MigrateError::pool(e, "getting connection for copy_rows_binary"))?;
 
-        let query = build_copy_query(schema, table, columns, pk_col, min_pk, max_pk);
+        let query = build_copy_query(
+            schema,
+            table,
+            columns,
+            pk_col,
+            min_pk,
+            max_pk,
+            resume_from_pk,
+            date_filter_column,
+            date_filter_timestamp.as_deref(),
+        );
         debug!("COPY query: {}", query);
 
         let copy_stream = client.copy_out(&query).await.map_err(|e| {
@@ -948,6 +974,9 @@ fn build_copy_query(
     pk_col: Option<&str>,
     min_pk: Option<i64>,
     max_pk: Option<i64>,
+    resume_from_pk: Option<i64>,
+    date_filter_column: Option<&str>,
+    date_filter_timestamp: Option<&str>,
 ) -> String {
     let col_list = columns
         .iter()
@@ -957,40 +986,40 @@ fn build_copy_query(
 
     let table_ref = format!("{}.{}", quote_ident(schema), quote_ident(table));
 
-    match (pk_col, min_pk, max_pk) {
-        (Some(pk), Some(min), Some(max)) => {
-            format!(
-                "COPY (SELECT {} FROM {} WHERE {} >= {} AND {} <= {} ORDER BY {}) TO STDOUT (FORMAT BINARY)",
-                col_list, table_ref, quote_ident(pk), min, quote_ident(pk), max, quote_ident(pk)
-            )
+    let mut conditions = Vec::new();
+
+    if let Some(pk) = pk_col {
+        let pk_quoted = quote_ident(pk);
+
+        if let Some(resume_pk) = resume_from_pk {
+            conditions.push(format!("{} > {}", pk_quoted, resume_pk));
+        } else if let Some(min) = min_pk {
+            conditions.push(format!("{} >= {}", pk_quoted, min));
         }
-        (Some(pk), Some(min), None) => {
-            format!(
-                "COPY (SELECT {} FROM {} WHERE {} >= {} ORDER BY {}) TO STDOUT (FORMAT BINARY)",
-                col_list,
-                table_ref,
-                quote_ident(pk),
-                min,
-                quote_ident(pk)
-            )
-        }
-        (Some(pk), None, Some(max)) => {
-            format!(
-                "COPY (SELECT {} FROM {} WHERE {} <= {} ORDER BY {}) TO STDOUT (FORMAT BINARY)",
-                col_list,
-                table_ref,
-                quote_ident(pk),
-                max,
-                quote_ident(pk)
-            )
-        }
-        _ => {
-            format!(
-                "COPY (SELECT {} FROM {}) TO STDOUT (FORMAT BINARY)",
-                col_list, table_ref
-            )
+
+        if let Some(max) = max_pk {
+            conditions.push(format!("{} <= {}", pk_quoted, max));
         }
     }
+
+    if let (Some(column), Some(timestamp)) = (date_filter_column, date_filter_timestamp) {
+        let date_quoted = quote_ident(column);
+        conditions.push(format!(
+            "({} > '{}' OR {} IS NULL)",
+            date_quoted, timestamp, date_quoted
+        ));
+    }
+
+    let mut query = format!("COPY (SELECT {} FROM {}", col_list, table_ref);
+    if !conditions.is_empty() {
+        query.push_str(" WHERE ");
+        query.push_str(&conditions.join(" AND "));
+    }
+    if let Some(pk) = pk_col {
+        query.push_str(&format!(" ORDER BY {}", quote_ident(pk)));
+    }
+    query.push_str(") TO STDOUT (FORMAT BINARY)");
+    query
 }
 
 /// Estimate the size of a PostgreSQL column.
@@ -1229,5 +1258,44 @@ mod tests {
             ordinal_pos: 1,
         };
         assert_eq!(estimate_column_size(&col), 4);
+    }
+
+    #[test]
+    fn test_build_copy_query_scopes_resume_as_exclusive() {
+        let query = build_copy_query(
+            "public",
+            "users",
+            &["id".to_string(), "name".to_string()],
+            Some("id"),
+            None,
+            Some(500),
+            Some(100),
+            None,
+            None,
+        );
+
+        assert!(query.contains("\"id\" > 100"));
+        assert!(query.contains("\"id\" <= 500"));
+        assert!(!query.contains("\"id\" >= 100"));
+    }
+
+    #[test]
+    fn test_build_copy_query_includes_incremental_date_filter() {
+        let query = build_copy_query(
+            "public",
+            "users",
+            &["id".to_string(), "updated_at".to_string()],
+            Some("id"),
+            Some(1),
+            Some(1000),
+            None,
+            Some("updated_at"),
+            Some("2026-04-15 10:30:00.000"),
+        );
+
+        assert!(query.contains("\"id\" >= 1"));
+        assert!(query.contains("\"id\" <= 1000"));
+        assert!(query
+            .contains("(\"updated_at\" > '2026-04-15 10:30:00.000' OR \"updated_at\" IS NULL)"));
     }
 }

--- a/crates/dmt-rs/src/drivers/postgres/reader.rs
+++ b/crates/dmt-rs/src/drivers/postgres/reader.rs
@@ -245,7 +245,9 @@ impl PostgresReader {
         max_pk: Option<i64>,
         resume_from_pk: Option<i64>,
         date_filter_column: Option<&str>,
+        date_filter_type: Option<&str>,
         date_filter_timestamp: Option<String>,
+        date_filter_timestamp_utc: Option<String>,
         tx: mpsc::Sender<Vec<Vec<SqlValue<'static>>>>,
         batch_size: usize,
     ) -> Result<i64> {
@@ -264,7 +266,9 @@ impl PostgresReader {
             max_pk,
             resume_from_pk,
             date_filter_column,
+            date_filter_type,
             date_filter_timestamp.as_deref(),
+            date_filter_timestamp_utc.as_deref(),
         );
         debug!("COPY query: {}", query);
 
@@ -334,7 +338,9 @@ impl PostgresReader {
         max_pk: Option<i64>,
         resume_from_pk: Option<i64>,
         date_filter_column: Option<&str>,
+        date_filter_type: Option<&str>,
         date_filter_timestamp: Option<String>,
+        date_filter_timestamp_utc: Option<String>,
         tx: mpsc::Sender<Vec<Vec<TargetSqlValue>>>,
         batch_size: usize,
     ) -> Result<i64> {
@@ -353,7 +359,9 @@ impl PostgresReader {
             max_pk,
             resume_from_pk,
             date_filter_column,
+            date_filter_type,
             date_filter_timestamp.as_deref(),
+            date_filter_timestamp_utc.as_deref(),
         );
         debug!("COPY query: {}", query);
 
@@ -976,7 +984,9 @@ fn build_copy_query(
     max_pk: Option<i64>,
     resume_from_pk: Option<i64>,
     date_filter_column: Option<&str>,
+    date_filter_type: Option<&str>,
     date_filter_timestamp: Option<&str>,
+    date_filter_timestamp_utc: Option<&str>,
 ) -> String {
     let col_list = columns
         .iter()
@@ -1002,12 +1012,27 @@ fn build_copy_query(
         }
     }
 
-    if let (Some(column), Some(timestamp)) = (date_filter_column, date_filter_timestamp) {
+    if let Some(column) = date_filter_column {
         let date_quoted = quote_ident(column);
-        conditions.push(format!(
-            "({} > '{}' OR {} IS NULL)",
-            date_quoted, timestamp, date_quoted
-        ));
+        let is_timestamptz = matches!(
+            date_filter_type.map(|t| t.to_lowercase()),
+            Some(ref t) if t == "timestamptz" || t == "timestamp with time zone"
+        );
+        let condition = if is_timestamptz {
+            let timestamp =
+                date_filter_timestamp_utc.expect("timezone-aware filter timestamp missing");
+            format!(
+                "({} > TIMESTAMPTZ '{}' OR {} IS NULL)",
+                date_quoted, timestamp, date_quoted
+            )
+        } else {
+            let timestamp = date_filter_timestamp.expect("date filter timestamp missing");
+            format!(
+                "({} > '{}' OR {} IS NULL)",
+                date_quoted, timestamp, date_quoted
+            )
+        };
+        conditions.push(condition);
     }
 
     let mut query = format!("COPY (SELECT {} FROM {}", col_list, table_ref);
@@ -1272,6 +1297,8 @@ mod tests {
             Some(100),
             None,
             None,
+            None,
+            None,
         );
 
         assert!(query.contains("\"id\" > 100"));
@@ -1290,12 +1317,33 @@ mod tests {
             Some(1000),
             None,
             Some("updated_at"),
+            Some("timestamp"),
             Some("2026-04-15 10:30:00.000"),
+            None,
         );
 
         assert!(query.contains("\"id\" >= 1"));
         assert!(query.contains("\"id\" <= 1000"));
         assert!(query
             .contains("(\"updated_at\" > '2026-04-15 10:30:00.000' OR \"updated_at\" IS NULL)"));
+    }
+
+    #[test]
+    fn test_build_copy_query_uses_explicit_utc_for_timestamptz_filter() {
+        let query = build_copy_query(
+            "public",
+            "users",
+            &["id".to_string(), "updated_at".to_string()],
+            Some("id"),
+            Some(1),
+            Some(1000),
+            None,
+            Some("updated_at"),
+            Some("timestamptz"),
+            Some("2026-04-15 10:30:00.000"),
+            Some("2026-04-15 10:30:00.000+00"),
+        );
+
+        assert!(query.contains("TIMESTAMPTZ '2026-04-15 10:30:00.000+00'"));
     }
 }

--- a/crates/dmt-rs/src/orchestrator/mod.rs
+++ b/crates/dmt-rs/src/orchestrator/mod.rs
@@ -1087,7 +1087,7 @@ impl Orchestrator {
 
                     if let Some(last_sync_ts) = last_sync {
                         // Incremental sync: only rows modified after last sync
-                        match DateFilter::new(col_name.clone(), last_sync_ts) {
+                        match DateFilter::new(col_name.clone(), col_type.clone(), last_sync_ts) {
                             Ok(filter) => {
                                 tables_incremental += 1;
                                 info!(
@@ -2365,13 +2365,25 @@ mod tests {
         completed.status = TaskStatus::Completed;
         completed.last_pk = Some(12345);
 
-        let resume_from_pk = if true && completed.status == TaskStatus::Completed {
-            None
-        } else {
-            completed.last_pk
-        };
+        let date_incremental_enabled = true;
+        let resume_from_pk =
+            if date_incremental_enabled && completed.status == TaskStatus::Completed {
+                None
+            } else {
+                completed.last_pk
+            };
 
         assert_eq!(resume_from_pk, None);
+
+        let date_incremental_enabled = false;
+        let resume_from_pk =
+            if date_incremental_enabled && completed.status == TaskStatus::Completed {
+                None
+            } else {
+                completed.last_pk
+            };
+
+        assert_eq!(resume_from_pk, Some(12345));
     }
 
     use crate::core::schema::Column;

--- a/crates/dmt-rs/src/orchestrator/mod.rs
+++ b/crates/dmt-rs/src/orchestrator/mod.rs
@@ -329,7 +329,10 @@ impl Orchestrator {
         self.catalog.wrap_mappers_with_ai(cache.clone());
         self.ai_cache = Some(cache);
         self.ai_config = Some(ai_config.clone());
-        info!("AI type mapping enabled (provider: {:?})", ai_config.provider);
+        info!(
+            "AI type mapping enabled (provider: {:?})",
+            ai_config.provider
+        );
         self
     }
 
@@ -569,10 +572,10 @@ impl Orchestrator {
         // AI warm-up: resolve unknown types via LLM before DDL generation
         #[cfg(feature = "ai")]
         if let (Some(ai_config), Some(ai_cache)) = (&self.ai_config, &self.ai_cache) {
-            let source_dialect = DriverCatalog::normalize_db_type(&self.config.source.r#type)
-                .unwrap_or("unknown");
-            let target_dialect = DriverCatalog::normalize_db_type(&self.config.target.r#type)
-                .unwrap_or("unknown");
+            let source_dialect =
+                DriverCatalog::normalize_db_type(&self.config.source.r#type).unwrap_or("unknown");
+            let target_dialect =
+                DriverCatalog::normalize_db_type(&self.config.target.r#type).unwrap_or("unknown");
             if let Some(mapper) = self.catalog.get_mapper(source_dialect, target_dialect) {
                 // Create a temporary AiTypeMapper just for warm-up scanning
                 let ai_mapper = crate::ai::AiTypeMapper::new(mapper, ai_cache.clone());
@@ -583,7 +586,10 @@ impl Orchestrator {
                         }
                     }
                     Err(e) => {
-                        warn!("Failed to create AI provider, using static type mappings: {}", e);
+                        warn!(
+                            "Failed to create AI provider, using static type mappings: {}",
+                            e
+                        );
                     }
                 }
             }
@@ -1076,7 +1082,7 @@ impl Orchestrator {
                     // Get last sync timestamp from database (queries historical completed runs)
                     let last_sync = self
                         .state_backend
-                        .get_last_sync_timestamp(&table_name)
+                        .get_last_sync_timestamp(&state.config_hash, &table_name)
                         .await?;
 
                     if let Some(last_sync_ts) = last_sync {
@@ -1218,7 +1224,13 @@ impl Orchestrator {
                 partition_id: None,
                 min_pk: None,
                 max_pk: None,
-                resume_from_pk: state.tables.get(&table_name).and_then(|ts| ts.last_pk),
+                resume_from_pk: state.tables.get(&table_name).and_then(|ts| {
+                    if date_incremental_enabled && ts.status == TaskStatus::Completed {
+                        None
+                    } else {
+                        ts.last_pk
+                    }
+                }),
                 target_mode: self.config.migration.target_mode,
                 target_schema: self.config.target.schema.clone(),
                 date_filter: date_filter.clone(),
@@ -2345,6 +2357,21 @@ mod tests {
         assert!(pending_tables.contains(&&"dbo.Orders"));
         assert!(pending_tables.contains(&&"dbo.Products"));
         assert!(!pending_tables.contains(&&"dbo.Users")); // Completed, should be skipped
+    }
+
+    #[test]
+    fn test_incremental_sync_ignores_last_pk_from_completed_table() {
+        let mut completed = TableState::new(1000);
+        completed.status = TaskStatus::Completed;
+        completed.last_pk = Some(12345);
+
+        let resume_from_pk = if true && completed.status == TaskStatus::Completed {
+            None
+        } else {
+            completed.last_pk
+        };
+
+        assert_eq!(resume_from_pk, None);
     }
 
     use crate::core::schema::Column;

--- a/crates/dmt-rs/src/orchestrator/pools.rs
+++ b/crates/dmt-rs/src/orchestrator/pools.rs
@@ -410,7 +410,9 @@ impl SourcePoolImpl {
         max_pk: Option<i64>,
         resume_from_pk: Option<i64>,
         date_filter_column: Option<&str>,
+        date_filter_type: Option<&str>,
         date_filter_timestamp: Option<String>,
+        date_filter_timestamp_utc: Option<String>,
         tx: mpsc::Sender<Vec<Vec<SqlValue>>>,
         batch_size: usize,
     ) -> Result<i64> {
@@ -426,7 +428,9 @@ impl SourcePoolImpl {
                     max_pk,
                     resume_from_pk,
                     date_filter_column,
+                    date_filter_type,
                     date_filter_timestamp,
+                    date_filter_timestamp_utc,
                     tx,
                     batch_size,
                 )

--- a/crates/dmt-rs/src/orchestrator/pools.rs
+++ b/crates/dmt-rs/src/orchestrator/pools.rs
@@ -408,13 +408,27 @@ impl SourcePoolImpl {
         pk_col: Option<&str>,
         min_pk: Option<i64>,
         max_pk: Option<i64>,
+        resume_from_pk: Option<i64>,
+        date_filter_column: Option<&str>,
+        date_filter_timestamp: Option<String>,
         tx: mpsc::Sender<Vec<Vec<SqlValue>>>,
         batch_size: usize,
     ) -> Result<i64> {
         match self {
             Self::Postgres(p) => {
                 p.copy_rows_binary_for_target(
-                    schema, table, columns, col_types, pk_col, min_pk, max_pk, tx, batch_size,
+                    schema,
+                    table,
+                    columns,
+                    col_types,
+                    pk_col,
+                    min_pk,
+                    max_pk,
+                    resume_from_pk,
+                    date_filter_column,
+                    date_filter_timestamp,
+                    tx,
+                    batch_size,
                 )
                 .await
             }

--- a/crates/dmt-rs/src/state/backend.rs
+++ b/crates/dmt-rs/src/state/backend.rs
@@ -75,8 +75,13 @@ pub trait StateBackend: Send + Sync {
     ///
     /// # Arguments
     ///
+    /// * `config_hash` - SHA256 hash of the migration configuration
     /// * `table_name` - Full table name (schema.table)
-    async fn get_last_sync_timestamp(&self, table_name: &str) -> Result<Option<DateTime<Utc>>>;
+    async fn get_last_sync_timestamp(
+        &self,
+        config_hash: &str,
+        table_name: &str,
+    ) -> Result<Option<DateTime<Utc>>>;
 
     /// Get the backend type name for logging/debugging.
     fn backend_type(&self) -> &'static str;

--- a/crates/dmt-rs/src/state/db.rs
+++ b/crates/dmt-rs/src/state/db.rs
@@ -228,7 +228,11 @@ impl DbStateBackend {
 
     /// Get the last sync timestamp for a specific table (for incremental sync).
     /// Returns the most recent completed run's timestamp for this table.
-    pub async fn get_last_sync_timestamp(&self, table_name: &str) -> Result<Option<DateTime<Utc>>> {
+    pub async fn get_last_sync_timestamp(
+        &self,
+        config_hash: &str,
+        table_name: &str,
+    ) -> Result<Option<DateTime<Utc>>> {
         let conn = self.pool.get().await?;
 
         let row = conn
@@ -236,14 +240,15 @@ impl DbStateBackend {
                 &format!(
                     "SELECT last_sync_timestamp
                      FROM {}.table_state
-                     WHERE table_name = $1
+                     WHERE config_hash = $1
+                       AND table_name = $2
                        AND table_status = 'completed'
                        AND last_sync_timestamp IS NOT NULL
                      ORDER BY updated_at DESC
                      LIMIT 1",
                     self.schema
                 ),
-                &[&table_name],
+                &[&config_hash, &table_name],
             )
             .await?;
 
@@ -271,8 +276,12 @@ impl StateBackend for DbStateBackend {
         DbStateBackend::load_latest(self, config_hash).await
     }
 
-    async fn get_last_sync_timestamp(&self, table_name: &str) -> Result<Option<DateTime<Utc>>> {
-        DbStateBackend::get_last_sync_timestamp(self, table_name).await
+    async fn get_last_sync_timestamp(
+        &self,
+        config_hash: &str,
+        table_name: &str,
+    ) -> Result<Option<DateTime<Utc>>> {
+        DbStateBackend::get_last_sync_timestamp(self, config_hash, table_name).await
     }
 
     fn backend_type(&self) -> &'static str {

--- a/crates/dmt-rs/src/state/db.rs
+++ b/crates/dmt-rs/src/state/db.rs
@@ -80,6 +80,17 @@ impl DbStateBackend {
         )
         .await?;
 
+        conn.execute(
+            &format!(
+                "CREATE INDEX IF NOT EXISTS idx_table_state_incremental_sync_by_config
+                    ON {}.table_state(config_hash, table_name, last_sync_timestamp DESC)
+                    WHERE table_status = 'completed' AND last_sync_timestamp IS NOT NULL",
+                self.schema
+            ),
+            &[],
+        )
+        .await?;
+
         // Create index for latest run lookups
         conn.execute(
             &format!(
@@ -244,7 +255,7 @@ impl DbStateBackend {
                        AND table_name = $2
                        AND table_status = 'completed'
                        AND last_sync_timestamp IS NOT NULL
-                     ORDER BY updated_at DESC
+                     ORDER BY last_sync_timestamp DESC
                      LIMIT 1",
                     self.schema
                 ),

--- a/crates/dmt-rs/src/state/mod.rs
+++ b/crates/dmt-rs/src/state/mod.rs
@@ -90,12 +90,28 @@ impl StateBackendEnum {
     }
 
     /// Get the last sync timestamp for a specific table.
-    pub async fn get_last_sync_timestamp(&self, table_name: &str) -> Result<Option<DateTime<Utc>>> {
+    pub async fn get_last_sync_timestamp(
+        &self,
+        config_hash: &str,
+        table_name: &str,
+    ) -> Result<Option<DateTime<Utc>>> {
         match self {
-            Self::Postgres(backend) => backend.get_last_sync_timestamp(table_name).await,
-            Self::Mssql(backend) => backend.get_last_sync_timestamp(table_name).await,
+            Self::Postgres(backend) => {
+                backend
+                    .get_last_sync_timestamp(config_hash, table_name)
+                    .await
+            }
+            Self::Mssql(backend) => {
+                backend
+                    .get_last_sync_timestamp(config_hash, table_name)
+                    .await
+            }
             #[cfg(feature = "mysql")]
-            Self::Mysql(backend) => backend.get_last_sync_timestamp(table_name).await,
+            Self::Mysql(backend) => {
+                backend
+                    .get_last_sync_timestamp(config_hash, table_name)
+                    .await
+            }
         }
     }
 
@@ -125,8 +141,12 @@ impl StateBackend for StateBackendEnum {
         StateBackendEnum::load_latest(self, config_hash).await
     }
 
-    async fn get_last_sync_timestamp(&self, table_name: &str) -> Result<Option<DateTime<Utc>>> {
-        StateBackendEnum::get_last_sync_timestamp(self, table_name).await
+    async fn get_last_sync_timestamp(
+        &self,
+        config_hash: &str,
+        table_name: &str,
+    ) -> Result<Option<DateTime<Utc>>> {
+        StateBackendEnum::get_last_sync_timestamp(self, config_hash, table_name).await
     }
 
     fn backend_type(&self) -> &'static str {

--- a/crates/dmt-rs/src/state/mssql_db.rs
+++ b/crates/dmt-rs/src/state/mssql_db.rs
@@ -257,20 +257,25 @@ impl MssqlStateBackend {
     }
 
     /// Get the last sync timestamp for a specific table (for incremental sync).
-    pub async fn get_last_sync_timestamp(&self, table_name: &str) -> Result<Option<DateTime<Utc>>> {
+    pub async fn get_last_sync_timestamp(
+        &self,
+        config_hash: &str,
+        table_name: &str,
+    ) -> Result<Option<DateTime<Utc>>> {
         let mut conn = self.pool.get_conn().await?;
 
         let sql = format!(
             "SELECT TOP 1 last_sync_timestamp
              FROM [{}].[table_state]
-             WHERE table_name = @P1
+             WHERE config_hash = @P1
+               AND table_name = @P2
                AND table_status = 'completed'
                AND last_sync_timestamp IS NOT NULL
              ORDER BY updated_at DESC",
             self.schema
         );
 
-        let rows = conn.query(sql, &[&table_name]).await?;
+        let rows = conn.query(sql, &[&config_hash, &table_name]).await?;
         let row: Option<Row> = rows
             .into_results()
             .await?
@@ -302,8 +307,12 @@ impl StateBackend for MssqlStateBackend {
         MssqlStateBackend::load_latest(self, config_hash).await
     }
 
-    async fn get_last_sync_timestamp(&self, table_name: &str) -> Result<Option<DateTime<Utc>>> {
-        MssqlStateBackend::get_last_sync_timestamp(self, table_name).await
+    async fn get_last_sync_timestamp(
+        &self,
+        config_hash: &str,
+        table_name: &str,
+    ) -> Result<Option<DateTime<Utc>>> {
+        MssqlStateBackend::get_last_sync_timestamp(self, config_hash, table_name).await
     }
 
     fn backend_type(&self) -> &'static str {

--- a/crates/dmt-rs/src/state/mssql_db.rs
+++ b/crates/dmt-rs/src/state/mssql_db.rs
@@ -42,6 +42,17 @@ impl MssqlStateBackend {
         );
         conn.execute(sql, &[]).await?;
 
+        let sql = format!(
+            "IF NOT EXISTS (SELECT * FROM sys.indexes WHERE name = 'idx_table_state_incremental_sync_by_config' AND object_id = OBJECT_ID('[{}].[table_state]'))
+             BEGIN
+                 CREATE INDEX idx_table_state_incremental_sync_by_config
+                 ON [{}].[table_state](config_hash, table_name, last_sync_timestamp DESC)
+                 WHERE table_status = 'completed' AND last_sync_timestamp IS NOT NULL
+             END",
+            self.schema, self.schema
+        );
+        conn.execute(sql, &[]).await?;
+
         // Create denormalized table_state table (includes run-level fields)
         let sql = format!(
             "IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'table_state' AND schema_id = SCHEMA_ID('{}'))
@@ -271,7 +282,7 @@ impl MssqlStateBackend {
                AND table_name = @P2
                AND table_status = 'completed'
                AND last_sync_timestamp IS NOT NULL
-             ORDER BY updated_at DESC",
+             ORDER BY last_sync_timestamp DESC",
             self.schema
         );
 

--- a/crates/dmt-rs/src/state/mysql_db.rs
+++ b/crates/dmt-rs/src/state/mysql_db.rs
@@ -262,7 +262,11 @@ impl MysqlStateBackend {
 
     /// Get the last sync timestamp for a specific table (for incremental sync).
     /// Returns the most recent completed run's timestamp for this table.
-    pub async fn get_last_sync_timestamp(&self, table_name: &str) -> Result<Option<DateTime<Utc>>> {
+    pub async fn get_last_sync_timestamp(
+        &self,
+        config_hash: &str,
+        table_name: &str,
+    ) -> Result<Option<DateTime<Utc>>> {
         let mut conn = self
             .pool
             .get_conn()
@@ -272,7 +276,8 @@ impl MysqlStateBackend {
         let sql = format!(
             "SELECT last_sync_timestamp
              FROM `{}`.`table_state`
-             WHERE table_name = ?
+             WHERE config_hash = ?
+               AND table_name = ?
                AND table_status = 'completed'
                AND last_sync_timestamp IS NOT NULL
              ORDER BY updated_at DESC
@@ -281,7 +286,7 @@ impl MysqlStateBackend {
         );
 
         let row: Option<MySqlRow> = conn
-            .exec_first(&sql, (table_name,))
+            .exec_first(&sql, (config_hash, table_name))
             .await
             .map_err(|e| MigrateError::pool(e, "getting MySQL last sync timestamp"))?;
 
@@ -313,8 +318,12 @@ impl StateBackend for MysqlStateBackend {
         MysqlStateBackend::load_latest(self, config_hash).await
     }
 
-    async fn get_last_sync_timestamp(&self, table_name: &str) -> Result<Option<DateTime<Utc>>> {
-        MysqlStateBackend::get_last_sync_timestamp(self, table_name).await
+    async fn get_last_sync_timestamp(
+        &self,
+        config_hash: &str,
+        table_name: &str,
+    ) -> Result<Option<DateTime<Utc>>> {
+        MysqlStateBackend::get_last_sync_timestamp(self, config_hash, table_name).await
     }
 
     fn backend_type(&self) -> &'static str {

--- a/crates/dmt-rs/src/state/mysql_db.rs
+++ b/crates/dmt-rs/src/state/mysql_db.rs
@@ -64,7 +64,8 @@ impl MysqlStateBackend {
                 updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
                 PRIMARY KEY (run_id, table_name),
                 INDEX idx_config_hash (config_hash, run_started_at DESC),
-                INDEX idx_incremental_sync (table_name, table_status, last_sync_timestamp)
+                INDEX idx_incremental_sync (table_name, table_status, last_sync_timestamp),
+                INDEX idx_incremental_sync_by_config (config_hash, table_name, table_status, last_sync_timestamp)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4",
             self.schema
         );
@@ -280,7 +281,7 @@ impl MysqlStateBackend {
                AND table_name = ?
                AND table_status = 'completed'
                AND last_sync_timestamp IS NOT NULL
-             ORDER BY updated_at DESC
+             ORDER BY last_sync_timestamp DESC
              LIMIT 1",
             self.schema
         );

--- a/crates/dmt-rs/src/transfer/mod.rs
+++ b/crates/dmt-rs/src/transfer/mod.rs
@@ -29,6 +29,8 @@ use tracing::{debug, info, warn};
 pub struct DateFilter {
     /// Date column name to filter on.
     pub column: String,
+    /// Source column type for database-specific literal rendering.
+    pub column_type: String,
     /// Only sync rows where column > timestamp (or column IS NULL).
     pub timestamp: DateTime<Utc>,
 }
@@ -42,7 +44,7 @@ impl DateFilter {
     /// - Rejects future timestamps (clock skew or tampering)
     /// - Rejects very old timestamps (likely corruption or tampering)
     /// - Column name validated separately during query building
-    pub fn new(column: String, timestamp: DateTime<Utc>) -> Result<Self> {
+    pub fn new(column: String, column_type: String, timestamp: DateTime<Utc>) -> Result<Self> {
         let now = Utc::now();
 
         // Reject timestamps more than 1 hour in the future (allows for clock skew)
@@ -65,7 +67,11 @@ impl DateFilter {
             )));
         }
 
-        Ok(Self { column, timestamp })
+        Ok(Self {
+            column,
+            column_type,
+            timestamp,
+        })
     }
 
     /// Get the timestamp as a validated ISO 8601 string suitable for SQL.
@@ -85,6 +91,21 @@ impl DateFilter {
         // Compatible with SQL Server datetime and PostgreSQL timestamp
         // No single quotes, no semicolons, no SQL injection risk
         self.timestamp.format("%Y-%m-%d %H:%M:%S%.3f").to_string()
+    }
+
+    /// Get the timestamp as an explicit UTC literal for timezone-aware PostgreSQL columns.
+    pub fn timestamp_sql_safe_utc(&self) -> String {
+        self.timestamp
+            .format("%Y-%m-%d %H:%M:%S%.3f+00")
+            .to_string()
+    }
+
+    /// Returns true when the source column carries timezone information.
+    pub fn is_timezone_aware(&self) -> bool {
+        matches!(
+            self.column_type.to_lowercase().as_str(),
+            "timestamptz" | "timestamp with time zone"
+        )
     }
 }
 
@@ -1135,12 +1156,21 @@ async fn read_chunk_keyset_fast(
         };
         // SECURITY: timestamp_sql_safe() returns bounds-validated ISO 8601 string
         // ISO 8601 format (YYYY-MM-DD HH:MM:SS.fff) contains no SQL metacharacters
-        let timestamp_str = filter.timestamp_sql_safe();
+        let condition = if is_postgres && filter.is_timezone_aware() {
+            let timestamp_str = filter.timestamp_sql_safe_utc();
+            format!(
+                "({} > TIMESTAMPTZ '{}' OR {} IS NULL)",
+                date_quoted, timestamp_str, date_quoted
+            )
+        } else {
+            let timestamp_str = filter.timestamp_sql_safe();
+            format!(
+                "({} > '{}' OR {} IS NULL)",
+                date_quoted, timestamp_str, date_quoted
+            )
+        };
         // Include NULL values to catch rows without timestamps
-        conditions.push(format!(
-            "({} > '{}' OR {} IS NULL)",
-            date_quoted, timestamp_str, date_quoted
-        ));
+        conditions.push(condition);
     }
 
     if !conditions.is_empty() {
@@ -1312,7 +1342,9 @@ async fn read_table_chunks_copy_binary(
     let max_pk = job.max_pk;
     let pk_col_clone = pk_col_name.clone();
     let date_filter_column = job.date_filter.as_ref().map(|f| f.column.clone());
+    let date_filter_type = job.date_filter.as_ref().map(|f| f.column_type.clone());
     let date_filter_timestamp = job.date_filter.as_ref().map(|f| f.timestamp_sql_safe());
+    let date_filter_timestamp_utc = job.date_filter.as_ref().map(|f| f.timestamp_sql_safe_utc());
 
     let copy_handle = tokio::spawn(async move {
         source_clone
@@ -1326,7 +1358,9 @@ async fn read_table_chunks_copy_binary(
                 max_pk,
                 job.resume_from_pk,
                 date_filter_column.as_deref(),
+                date_filter_type.as_deref(),
                 date_filter_timestamp,
+                date_filter_timestamp_utc,
                 copy_tx,
                 chunk_size,
             )

--- a/crates/dmt-rs/src/transfer/mod.rs
+++ b/crates/dmt-rs/src/transfer/mod.rs
@@ -347,7 +347,11 @@ impl TransferEngine {
     /// For partitioned tables, the orchestrator shares a single token across all
     /// partitions of the same table — so a failure in any partition cancels its
     /// siblings without waiting for the orchestrator's result-collection loop.
-    pub async fn execute(&self, job: TransferJob, cancel: CancellationToken) -> Result<TransferStats> {
+    pub async fn execute(
+        &self,
+        job: TransferJob,
+        cancel: CancellationToken,
+    ) -> Result<TransferStats> {
         let table_name = job.table.full_name();
         info!(
             "Starting transfer for {} (mode: {:?}, readers: {}, writers: {})",
@@ -1307,6 +1311,8 @@ async fn read_table_chunks_copy_binary(
     let min_pk = job.min_pk.or(job.resume_from_pk);
     let max_pk = job.max_pk;
     let pk_col_clone = pk_col_name.clone();
+    let date_filter_column = job.date_filter.as_ref().map(|f| f.column.clone());
+    let date_filter_timestamp = job.date_filter.as_ref().map(|f| f.timestamp_sql_safe());
 
     let copy_handle = tokio::spawn(async move {
         source_clone
@@ -1318,6 +1324,9 @@ async fn read_table_chunks_copy_binary(
                 pk_col_clone.as_deref(),
                 min_pk,
                 max_pk,
+                job.resume_from_pk,
+                date_filter_column.as_deref(),
+                date_filter_timestamp,
                 copy_tx,
                 chunk_size,
             )

--- a/e2e-pg-watermark-users.yaml
+++ b/e2e-pg-watermark-users.yaml
@@ -1,0 +1,29 @@
+source:
+  type: postgres
+  host: localhost
+  port: 5432
+  database: so2010_bench
+  schema: public
+  user: postgres
+  password: TestPass2024
+  ssl_mode: disable
+
+target:
+  type: postgres
+  host: localhost
+  port: 5434
+  database: so2010_incremental_test
+  schema: public
+  user: postgres
+  password: TestPass2024
+  ssl_mode: disable
+
+migration:
+  target_mode: upsert
+  workers: 2
+  chunk_size: 50000
+  date_updated_columns:
+    - LastAccessDate
+    - CreationDate
+  include_tables:
+    - users


### PR DESCRIPTION
## Summary
- scope incremental-sync watermark lookups by `config_hash` instead of just `table_name`
- apply date-based incremental filters in the PostgreSQL `COPY TO BINARY` read path
- stop reusing `last_pk` for completed date-based incremental reruns so watermark-only syncs do not skip valid changed rows
- add a Docker E2E config for PostgreSQL StackOverflow 2010 incremental validation

## Validation
- `cargo test`
- Docker E2E against StackOverflow 2010 `public.users` using `pg-bench` -> `pg-target`
- initial full sync transferred `299398` rows
- incremental rerun after updating 2 source rows transferred exactly `2` rows on the PostgreSQL `COPY TO BINARY` path
- restored the 2 modified source rows after the E2E test