### PR TITLE
chore: release v1.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.44.0] - 2026-04-17
+
+### Features
+- **Share state across `target_mode`** (#108) — `config_hash` now excludes `target_mode`, so a `drop_recreate` run seeds watermarks that a subsequent `upsert` run inherits. Post-drop upsert with no source changes completes in ~6s instead of paying the full first-upsert tax.
+- **Dialect-specific AI prompt augmentation** (#106) — AI type mapping prompts now include dialect-specific context (type quirks, reserved words) for better cross-DB type resolution.
+- Seeded `date_updated_columns` defaults in the 18 bundled test configs for out-of-the-box incremental sync.
+
+### Bug Fixes
+- **Cross-engine `datetime2` → `datetime`** (#109) — MSSQL targets now use `datetime` rather than `datetime2` when the source is a different engine, working around a bulk-insert driver issue with `datetime2`.
+- **MSSQL state init order** (#107) — state schema is now initialized before any writes; previously could race during cold-start.
+- **MySQL source TLS** — fixed TLS handshake failures when MySQL is the source.
+- **AI config on resume** (#105) — `dmt-rs resume` now loads the AI global config; previously only `run` did.
+- **Incremental sync watermark / resume** — multiple fixes to date-watermark handling during resume, including identity-mapper and datetime bulk-insert edge cases.
+
+### Tests / Chore
+- Standardized all 18 test configs (#109) — consistent formatting, shared `TestPass2024` password, hash-parity between drop/upsert variant pairs.
+
+### Documentation
+- M5 Pro cgroup-cap benchmark findings — Config E (41.1s `mssql→mssql` on 12 GiB VM with per-container 5 GiB cgroup cap) added to the cross-hardware table.
+- Incremental upsert-after-drop playbook section (§11).
+
 ## [1.43.0] - 2026-04-14
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "dmt-rs"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "dmt-rs-cli"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/dmt-rs", "crates/dmt-rs-cli"]
 
 [workspace.package]
-version = "1.43.0"
+version = "1.44.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/docs/benchmark-playbook.md
+++ b/docs/benchmark-playbook.md
@@ -155,7 +155,7 @@ Build the binary:
 
 ```bash
 cargo build --release --all-features
-./target/release/dmt-rs --version   # should report: dmt-rs 1.42.2 (or later)
+./target/release/dmt-rs --version   # should report: dmt-rs 1.44.0 (or later)
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Bumps workspace version 1.43.0 → 1.44.0
- Prepends CHANGELOG entry documenting PRs #105–#109 plus incremental-sync fixes
- Updates benchmark playbook's "minimum version" hint (1.42.2 → 1.44.0)
- `cargo build --release` confirms binary reports `dmt-rs 1.44.0`

## Highlights since v1.43.0
- **Features**: drop→upsert state sharing via `target_mode`-excluded `config_hash` (#108), dialect-specific AI prompt augmentation (#106), seeded `date_updated_columns` in bundled test configs
- **Fixes**: cross-engine `datetime2` → `datetime` (#109), MSSQL state init order (#107), MySQL source TLS, AI config on resume (#105), several incremental-sync watermark/resume edge cases
- **Chore**: standardized all 18 test configs (#109)
- **Docs**: M5 Pro cgroup-cap benchmark Config E (41.1s mssql→mssql on 12 GiB VM), incremental-upsert playbook §11

## Test plan
- [x] `cargo build --release` succeeds
- [x] `./target/release/dmt-rs --version` → `dmt-rs 1.44.0`
- [ ] Tag `v1.44.0` from main after merge
- [ ] (Optional) release binaries build + upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)