### PR TITLE
perf(mysql): bulk-load session tuning + MySQL-aware pool sizing

### DIFF
--- a/crates/dmt-rs/src/config/mod.rs
+++ b/crates/dmt-rs/src/config/mod.rs
@@ -625,6 +625,49 @@ migration:
         );
     }
 
+    // ============== MySQL bulk session tuning config tests ==============
+
+    #[test]
+    fn test_mysql_bulk_session_tuning_defaults_true_from_yaml() {
+        // Covers the user-facing default: when the field is omitted from YAML,
+        // serde must still produce `true`. This guards against accidentally
+        // dropping `#[serde(default = "default_true")]` on the field.
+        let config = Config::from_yaml(VALID_YAML).unwrap();
+        assert!(config.migration.mysql_bulk_session_tuning);
+    }
+
+    #[test]
+    fn test_mysql_bulk_session_tuning_explicit_false() {
+        let yaml = r#"
+source:
+  type: mssql
+  host: localhost
+  port: 1433
+  database: source_db
+  user: sa
+  password: password
+  schema: dbo
+  encrypt: false
+  trust_server_cert: true
+
+target:
+  type: mysql
+  host: localhost
+  port: 3306
+  database: target_db
+  user: root
+  password: password
+  ssl_mode: disable
+
+migration:
+  workers: 4
+  chunk_size: 100000
+  mysql_bulk_session_tuning: false
+"#;
+        let config = Config::from_yaml(yaml).unwrap();
+        assert!(!config.migration.mysql_bulk_session_tuning);
+    }
+
     #[test]
     fn test_mysql_load_data_invalid_value() {
         let yaml = r#"

--- a/crates/dmt-rs/src/config/types.rs
+++ b/crates/dmt-rs/src/config/types.rs
@@ -435,6 +435,10 @@ pub struct MigrationConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_pg_connections: Option<usize>,
 
+    /// Maximum MySQL/MariaDB connections. Auto-tuned based on workers if not set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_mysql_connections: Option<usize>,
+
     /// Minimum rows per partition when splitting large tables.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub min_rows_per_partition: Option<i64>,
@@ -493,6 +497,15 @@ pub struct MigrationConfig {
     /// This reduces memory pressure for tables with large text columns.
     #[serde(default)]
     pub compress_text: bool,
+
+    /// Apply MySQL bulk-load session tuning on writer connections (default: true).
+    /// When enabled, writer connections run `SET SESSION unique_checks=0` and
+    /// `SET SESSION foreign_key_checks=0` at connect time. Integrity is still
+    /// enforced by the source data (FKs and UNIQUEs were valid there); disabling
+    /// these checks removes per-row overhead that is the dominant cost on
+    /// foreign-key-heavy schemas. Set to `false` to keep the MySQL defaults.
+    #[serde(default = "default_true")]
+    pub mysql_bulk_session_tuning: bool,
 }
 
 impl Default for MigrationConfig {
@@ -513,6 +526,7 @@ impl Default for MigrationConfig {
             create_check_constraints: false,
             max_mssql_connections: None,
             max_pg_connections: None,
+            max_mysql_connections: None,
             min_rows_per_partition: None,
             finalizer_concurrency: None,
             copy_buffer_rows: None,
@@ -524,6 +538,7 @@ impl Default for MigrationConfig {
             memory_budget_percent: default_memory_budget_percent(),
             mysql_load_data: MysqlLoadData::default(),
             compress_text: false,
+            mysql_bulk_session_tuning: true,
         }
     }
 }
@@ -757,6 +772,15 @@ impl MigrationConfig {
             self.max_pg_connections = Some(conns);
         }
 
+        // MySQL connections: bound by both reader and writer parallelism since
+        // MySQL can be either source or target. Use the larger of the two.
+        if self.max_mysql_connections.is_none() {
+            let readers = self.parallel_readers.unwrap_or(4);
+            let writers = self.write_ahead_writers.unwrap_or(4);
+            let conns = (workers * readers.max(writers) + 4).clamp(8, 64);
+            self.max_mysql_connections = Some(conns);
+        }
+
         // Upsert batch size: scale with RAM (more aggressive for better throughput)
         // Larger batches reduce round-trips but use more memory
         if self.upsert_batch_size.is_none() {
@@ -796,10 +820,11 @@ impl MigrationConfig {
             memory_budget_mb,
         );
         info!(
-            "  large_table_threshold={}, mssql_conns={}, pg_conns={}",
+            "  large_table_threshold={}, mssql_conns={}, pg_conns={}, mysql_conns={}",
             self.large_table_threshold.unwrap(),
             self.max_mssql_connections.unwrap(),
             self.max_pg_connections.unwrap(),
+            self.max_mysql_connections.unwrap(),
         );
 
         self
@@ -858,6 +883,10 @@ impl MigrationConfig {
 
     pub fn get_max_pg_connections(&self) -> usize {
         self.max_pg_connections.unwrap_or(40)
+    }
+
+    pub fn get_max_mysql_connections(&self) -> usize {
+        self.max_mysql_connections.unwrap_or(40)
     }
 
     pub fn get_copy_buffer_rows(&self) -> usize {

--- a/crates/dmt-rs/src/config/validation.rs
+++ b/crates/dmt-rs/src/config/validation.rs
@@ -400,16 +400,6 @@ mod tests {
     }
 
     #[test]
-    fn test_mysql_bulk_session_tuning_defaults_true() {
-        let config = valid_config();
-        assert!(
-            config.migration.mysql_bulk_session_tuning,
-            "mysql_bulk_session_tuning must default to true so new users get the \
-             bulk-load speedup without opting in"
-        );
-    }
-
-    #[test]
     fn test_zero_finalizer_concurrency_rejected() {
         let mut config = valid_config();
         config.migration.finalizer_concurrency = Some(0);

--- a/crates/dmt-rs/src/config/validation.rs
+++ b/crates/dmt-rs/src/config/validation.rs
@@ -104,6 +104,10 @@ pub fn validate(config: &Config) -> Result<()> {
         "migration.max_pg_connections",
     )?;
     validate_nonzero_option(
+        config.migration.max_mysql_connections,
+        "migration.max_mysql_connections",
+    )?;
+    validate_nonzero_option(
         config.migration.finalizer_concurrency,
         "migration.finalizer_concurrency",
     )?;
@@ -381,6 +385,28 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("max_pg_connections"));
+    }
+
+    #[test]
+    fn test_zero_max_mysql_connections_rejected() {
+        let mut config = valid_config();
+        config.migration.max_mysql_connections = Some(0);
+        let result = validate(&config);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("max_mysql_connections"));
+    }
+
+    #[test]
+    fn test_mysql_bulk_session_tuning_defaults_true() {
+        let config = valid_config();
+        assert!(
+            config.migration.mysql_bulk_session_tuning,
+            "mysql_bulk_session_tuning must default to true so new users get the \
+             bulk-load speedup without opting in"
+        );
     }
 
     #[test]

--- a/crates/dmt-rs/src/core/catalog.rs
+++ b/crates/dmt-rs/src/core/catalog.rs
@@ -338,6 +338,8 @@ impl DriverCatalog {
     /// * `max_conns` - Maximum connection pool size
     /// * `source_db_type` - The source database type (for type mapping)
     /// * `mysql_load_data` - MySQL bulk load strategy (only used for MySQL targets)
+    /// * `mysql_bulk_session_tuning` - Whether to apply bulk-load session tuning
+    ///   (`unique_checks=0`, `foreign_key_checks=0`) on MySQL writer connections
     ///
     /// # Returns
     ///
@@ -349,6 +351,7 @@ impl DriverCatalog {
         max_conns: usize,
         source_db_type: &str,
         #[cfg(feature = "mysql")] mysql_load_data: crate::config::MysqlLoadData,
+        #[cfg(feature = "mysql")] mysql_bulk_session_tuning: bool,
     ) -> Result<TargetWriterImpl> {
         let db_type = config.r#type.to_lowercase();
         let target_type = match db_type.as_str() {
@@ -389,7 +392,13 @@ impl DriverCatalog {
             }
             #[cfg(feature = "mysql")]
             "mysql" | "mariadb" => {
-                let mut writer = MysqlWriter::new(config, max_conns, mysql_load_data).await?;
+                let mut writer = MysqlWriter::new(
+                    config,
+                    max_conns,
+                    mysql_load_data,
+                    mysql_bulk_session_tuning,
+                )
+                .await?;
                 if let Some(mapper) = type_mapper {
                     writer = writer.with_type_mapper(mapper);
                 }

--- a/crates/dmt-rs/src/drivers/mysql/writer.rs
+++ b/crates/dmt-rs/src/drivers/mysql/writer.rs
@@ -32,10 +32,16 @@ pub struct MysqlWriter {
 
 impl MysqlWriter {
     /// Create a new MySQL writer from configuration.
+    ///
+    /// When `bulk_session_tuning` is true, each pooled connection runs
+    /// `SET SESSION unique_checks=0` and `SET SESSION foreign_key_checks=0`
+    /// at connect time to reduce per-row overhead during bulk ingest. Source
+    /// data is assumed to have satisfied these constraints already.
     pub async fn new(
         config: &TargetConfig,
         max_conns: usize,
         mysql_load_data: MysqlLoadData,
+        bulk_session_tuning: bool,
     ) -> Result<Self> {
         let ssl_opts = match config.ssl_mode.to_lowercase().as_str() {
             "disable" => {
@@ -67,14 +73,26 @@ impl MysqlWriter {
             }
         };
 
+        // Per-connection initialization statements. Run on each pooled connection
+        // when it's first created. Anything here MUST work on every targeted MySQL
+        // flavor/version — a failure bricks the entire pool.
+        let mut init_stmts: Vec<String> = vec!["SET NAMES utf8mb4".to_string()];
+        if bulk_session_tuning {
+            // Source-side integrity is the source of truth during bulk loads, so
+            // the target doesn't need to re-verify it per row. These two are
+            // session-settable on every MySQL/MariaDB version we support and
+            // don't require elevated privileges on managed services (RDS etc.).
+            init_stmts.push("SET SESSION unique_checks = 0".to_string());
+            init_stmts.push("SET SESSION foreign_key_checks = 0".to_string());
+        }
+
         let mut builder = OptsBuilder::default()
             .ip_or_hostname(&config.host)
             .tcp_port(config.port)
             .db_name(Some(&config.database))
             .user(Some(&config.user))
             .pass(Some(&config.password))
-            // Use utf8mb4 for full Unicode support
-            .init(vec!["SET NAMES utf8mb4"]);
+            .init(init_stmts);
 
         if let Some(ssl) = ssl_opts {
             builder = builder.ssl_opts(ssl);

--- a/crates/dmt-rs/src/orchestrator/mod.rs
+++ b/crates/dmt-rs/src/orchestrator/mod.rs
@@ -468,6 +468,8 @@ impl Orchestrator {
                 source_db_type,
                 #[cfg(feature = "mysql")]
                 self.config.migration.mysql_load_data,
+                #[cfg(feature = "mysql")]
+                self.config.migration.mysql_bulk_session_tuning,
             )
             .await
     }

--- a/crates/dmt-rs/src/orchestrator/pools.rs
+++ b/crates/dmt-rs/src/orchestrator/pools.rs
@@ -236,8 +236,12 @@ impl SourcePoolImpl {
             // MySQL/MariaDB source - uses SQLx
             #[cfg(feature = "mysql")]
             {
-                mysql_info!("Creating MySQL source connection pool");
-                let reader = MysqlReader::new(&config.source, pool_size as usize).await?;
+                let mysql_pool_size = config.migration.get_max_mysql_connections();
+                mysql_info!(
+                    "Creating MySQL source connection pool (size={})",
+                    mysql_pool_size
+                );
+                let reader = MysqlReader::new(&config.source, mysql_pool_size).await?;
                 Ok(Self::Mysql(Arc::new(reader)))
             }
             #[cfg(not(feature = "mysql"))]
@@ -566,10 +570,19 @@ impl TargetPoolImpl {
             #[cfg(feature = "mysql")]
             {
                 use crate::dialect::{MssqlToMysqlMapper, PostgresToMysqlMapper};
-                mysql_info!("Creating MySQL target connection pool");
-                let writer =
-                    MysqlWriter::new(&config.target, max_conns, config.migration.mysql_load_data)
-                        .await?;
+                let mysql_pool_size = config.migration.get_max_mysql_connections();
+                mysql_info!(
+                    "Creating MySQL target connection pool (size={}, bulk_session_tuning={})",
+                    mysql_pool_size,
+                    config.migration.mysql_bulk_session_tuning
+                );
+                let writer = MysqlWriter::new(
+                    &config.target,
+                    mysql_pool_size,
+                    config.migration.mysql_load_data,
+                    config.migration.mysql_bulk_session_tuning,
+                )
+                .await?;
                 // Add type mapper based on source database type
                 let source_type = config.source.r#type.to_lowercase();
                 let writer = if source_type == "postgres"


### PR DESCRIPTION
## Summary

- Writer connections now run `SET SESSION unique_checks=0` and `SET SESSION foreign_key_checks=0` at connect time (opt-out via `migration.mysql_bulk_session_tuning`, default `true`). Source data already satisfied these constraints — re-checking them per row is the dominant per-row overhead on foreign-key-heavy schemas.
- New `migration.max_mysql_connections` config knob replaces borrowing `max_mssql_connections` / `max_pg_connections` for MySQL source and target pools. Auto-tuned alongside the existing pool knobs.
- Both knobs are covered by new unit tests (zero-rejection validation + default-on assertion).

Only the two safest, session-settable, no-privilege-required vars are applied. `sql_log_bin` and `innodb_flush_log_at_trx_commit` were deliberately skipped — both can fail on managed MySQL (RDS etc.), and a failure inside `OptsBuilder::init` bricks the whole pool.

Benchmark baseline for MySQL is intentionally a follow-up PR (no published MySQL numbers exist today, and standing up a MySQL bench container conflicts with the "2 DB containers at a time" constraint).

## Test plan

- [x] `cargo build` (no features)
- [x] `cargo build --features mysql`
- [x] `cargo test --lib` — 309 pass
- [x] `cargo test --lib --features mysql` — 324 pass
- [x] New `test_zero_max_mysql_connections_rejected` + `test_mysql_bulk_session_tuning_defaults_true` pass
- [ ] End-to-end MySQL target run against a real server (follow-up with benchmark harness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)