### PR TITLE
bench: first published MySQL target baseline + tuning A/B

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,8 @@ test-config.yaml
 *.log
 migration-logs-*.txt
 
+# Local benchmark artifacts
+.bench-logs/
+
 # Screenshots
 Screenshot*.png

--- a/benchmark-mssql-to-mysql-tuning-off.yaml
+++ b/benchmark-mssql-to-mysql-tuning-off.yaml
@@ -1,0 +1,26 @@
+source:
+  type: mssql
+  host: localhost
+  port: 1433
+  database: StackOverflow2010
+  user: sa
+  password: "TestPass2024"
+  schema: dbo
+  encrypt: false
+  trust_server_cert: true
+
+target:
+  type: mysql
+  host: localhost
+  port: 3307
+  database: stackoverflow_target
+  schema: stackoverflow_target
+  user: root
+  password: "TestPass2024"
+  ssl_mode: disable
+
+migration:
+  target_mode: drop_recreate
+  workers: 4
+  chunk_size: 50000
+  mysql_bulk_session_tuning: false

--- a/benchmark-mssql-to-mysql-tuning-on.yaml
+++ b/benchmark-mssql-to-mysql-tuning-on.yaml
@@ -1,0 +1,26 @@
+source:
+  type: mssql
+  host: localhost
+  port: 1433
+  database: StackOverflow2010
+  user: sa
+  password: "TestPass2024"
+  schema: dbo
+  encrypt: false
+  trust_server_cert: true
+
+target:
+  type: mysql
+  host: localhost
+  port: 3307
+  database: stackoverflow_target
+  schema: stackoverflow_target
+  user: root
+  password: "TestPass2024"
+  ssl_mode: disable
+
+migration:
+  target_mode: drop_recreate
+  workers: 4
+  chunk_size: 50000
+  mysql_bulk_session_tuning: true

--- a/docs/mysql-baseline.md
+++ b/docs/mysql-baseline.md
@@ -1,0 +1,136 @@
+# MySQL target — first published baseline
+
+This is dmt-rs's first published performance baseline for a **MySQL target**.
+Prior benchmarks in the repo (`BENCHMARKS.md`, `benchmark-results-m3-max.md`)
+only cover MSSQL↔PostgreSQL.
+
+## TL;DR
+
+On the default data-warehouse-style config (no secondary indexes, no foreign
+keys) migrating 19.3M rows from MSSQL → MySQL, `mysql_bulk_session_tuning`
+has **no path to help and a measurable 14% cost**:
+
+| config | n | median wall (s) | median rows/s |
+|---|---|---|---|
+| `mysql_bulk_session_tuning: true`  | 3 | 427.14 | 45,227 |
+| `mysql_bulk_session_tuning: false` | 3 | 365.42 | 52,864 |
+
+This is the **opposite** of the 5–15% gain predicted when #111 shipped. The
+reason is scope: the tuning's hot paths are not exercised by this config.
+See "Why tuning hurts here" below and the open question about the default.
+
+## Environment
+
+| Item | Value |
+|---|---|
+| Host | M5 Pro, 24 GB RAM, 15 cores (macOS 15.4.0) |
+| Source | MSSQL 2022 in Docker (`mssql-bench`, port 1433) |
+| Target | MySQL 8.0 in Docker (`mysql-target`, port 3307, 3 GB memory cap) |
+| Dataset | StackOverflow2010 — 9 tables, 19,310,703 rows |
+| Build | `cargo build --release --features mysql` at `46d1818` |
+| Workers / chunk | 4 workers, 50,000-row chunks (same in both variants) |
+| Create indexes / FKs | **false** (dmt-rs defaults) |
+
+Only `mysql_bulk_session_tuning` differs between the two variants; all other
+knobs are identical. See `benchmark-mssql-to-mysql-tuning-on.yaml` and
+`benchmark-mssql-to-mysql-tuning-off.yaml` for the exact configs.
+
+## Methodology
+
+Reproducer: `scripts/bench-mysql-tuning.sh`.
+
+* Every run drops + recreates the MySQL target database so each measurement
+  starts against an empty target.
+* A discarded warm-up run primes the MSSQL source buffer pool before any
+  measurement, so the first measured variant isn't penalized by a cold cache.
+* Variant order is **interleaved** — `on, off, off, on, on, off` — so any
+  residual system drift during the run can't systematically align with one
+  variant.
+* Three observations per variant; we report the median.
+* All per-run logs are captured in `.bench-logs/` and summarized in
+  `results.tsv`.
+
+## Raw results
+
+Order is the order the script executed them, not the order they appear in
+the config files. Wall time is measured externally; dmt-rs duration comes
+from its own summary block.
+
+| config     | run | wall (s) | dmt (s) | rows/s |
+|------------|-----|---------:|--------:|-------:|
+| tuning-on  | 1   | 430.54   | 430.34  | 44,872 |
+| tuning-off | 1   | 365.42   | 365.28  | 52,864 |
+| tuning-off | 2   | 330.16   | 330.00  | 58,517 |
+| tuning-on  | 2   | 377.41   | 377.27  | 51,184 |
+| tuning-on  | 3   | 427.14   | 426.96  | 45,227 |
+| tuning-off | 3   | 371.15   | 371.03  | 52,046 |
+
+Every tuning-off run is faster than every tuning-on run. The distributions
+do not overlap, so this is not variance — tuning-on really is slower on
+this config.
+
+## Why tuning hurts here
+
+PR #111 sets two MySQL session variables at connect time:
+
+* `SET SESSION unique_checks = 0` — tells InnoDB to skip per-row uniqueness
+  checks on **secondary** indexes during `INSERT`. No effect on the
+  clustered/primary index. No effect on DDL uniqueness enforcement.
+* `SET SESSION foreign_key_checks = 0` — skips FK validation on INSERT /
+  UPDATE / DELETE, and also skips the "validate existing rows" scan that
+  `ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY` performs.
+
+dmt-rs's **default** migration config sets `create_indexes: false` and
+`create_foreign_keys: false`. On this benchmark:
+
+* No secondary indexes exist during the bulk load → `unique_checks=0` has
+  nothing to skip.
+* No FKs are created at all → `foreign_key_checks=0` has nothing to skip.
+
+So both tuning knobs are inert on this workload. The only observable
+behavior change is InnoDB's "bulk insert mode" path that gets selected
+when `unique_checks=0`. That path defers secondary-index updates into
+the change buffer for later merge; on a schema with no secondary indexes
+the deferral has no payoff, and the 3 GB InnoDB buffer on the container
+means the bookkeeping is pure overhead. That's the most plausible
+explanation for the ~14% anti-gain. Confirming it would require InnoDB
+status counters (`innodb_buffer_pool_stats`, `innodb_change_buffer_stats`)
+sampled across runs — a follow-up if needed.
+
+## What this means for #111
+
+The tuning is still correct **for the workloads it was designed for** —
+runs with `create_indexes: true` and/or `create_foreign_keys: true` where
+post-load DDL would otherwise do a full table scan to validate constraints.
+On those, we expect the original 5–15% win to materialize.
+
+But this baseline does **not** confirm that. The next step is a second
+benchmark with `create_indexes: true, create_foreign_keys: true` on the
+same dataset. If that benchmark shows the predicted win (and this one
+shows a loss), the right answer may be to **flip the default** of
+`mysql_bulk_session_tuning` to `false` and have the finalize phase
+set the vars to 0 only for the FK-creation transactions where they
+actually help.
+
+That's a separate PR. Captured as a known question, not an action item
+for this one.
+
+## How to reproduce
+
+```bash
+# Ensure containers are in place
+docker start mssql-bench mysql-target
+
+# Build
+cargo build --release --features mysql
+
+# Run (takes ~45 min: warm-up + 6 measured runs on a 24 GB Mac)
+./scripts/bench-mysql-tuning.sh
+
+# Results
+cat .bench-logs/results.tsv
+```
+
+Override run count by exporting `RUNS=N` (note: the script's interleave
+pattern currently hard-codes 3 per variant — adjust the `ORDER` array if
+you want more).

--- a/docs/mysql-baseline.md
+++ b/docs/mysql-baseline.md
@@ -131,6 +131,6 @@ cargo build --release --features mysql
 cat .bench-logs/results.tsv
 ```
 
-Override run count by exporting `RUNS=N` (note: the script's interleave
-pattern currently hard-codes 3 per variant — adjust the `ORDER` array if
-you want more).
+The script hard-codes 3 runs per variant in its `ORDER` array. To change
+the run count or sequence, edit that array in `scripts/bench-mysql-tuning.sh`.
+Override the MySQL test password with `MYSQL_ROOT_PASSWORD=...`.

--- a/scripts/bench-mysql-tuning.sh
+++ b/scripts/bench-mysql-tuning.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# MySQL tuning A/B benchmark.
+#
+# Runs MSSQL -> MySQL drop_recreate of StackOverflow2010 with
+# `mysql_bulk_session_tuning` on and off, three times each, and prints
+# a markdown table of durations and throughput.
+#
+# Methodology:
+#  * The target DB is dropped + recreated between runs so every run starts
+#    from an empty target. The MSSQL source buffer pool is intentionally
+#    NOT flushed — both variants see the same warm cache by the time
+#    measurement starts (see warm-up below).
+#  * A discarded warm-up run is performed first to prime the MSSQL buffer
+#    pool. Without this, whichever variant ran first would be systematically
+#    penalized by the cold cache.
+#  * Variant order is interleaved (on/off/off/on/on/off) rather than
+#    grouped, so any residual drift in system state cannot align with one
+#    variant. Three observations per variant; we report the median.
+#
+# Expects:
+#   - mssql-bench    container running, StackOverflow2010 on :1433
+#   - mysql-target   container running, listening on :3307
+#   - ./target/release/dmt-rs built with --features mysql
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BINARY="$SCRIPT_DIR/target/release/dmt-rs"
+LOG_DIR="${LOG_DIR:-$SCRIPT_DIR/.bench-logs}"
+
+# Runs per variant are hard-coded in the ORDER array below (see "Interleaved
+# order" comment). Edit ORDER to change either count or sequence.
+
+mkdir -p "$LOG_DIR"
+
+if [ ! -x "$BINARY" ]; then
+  echo "error: $BINARY not found. Build with: cargo build --release --features mysql" >&2
+  exit 1
+fi
+
+MYSQL_CMD=(docker exec -i mysql-target mysql -uroot -pTestPass2024 -N -B)
+
+reset_target() {
+  "${MYSQL_CMD[@]}" -e "DROP DATABASE IF EXISTS stackoverflow_target; CREATE DATABASE stackoverflow_target CHARACTER SET utf8mb4;" 2>/dev/null
+}
+
+# Parse dmt-rs's trailing summary block. Uses -a so ANSI color codes in the
+# log don't trip grep's binary-file detection, and anchors against the exact
+# summary lines (two-space indent) so mid-run INFO lines can't leak in.
+parse_metric() {
+  local log="$1"
+  local label="$2"   # Duration | Rows | Throughput
+  grep -aE "^  ${label}: " "$log" | tail -1 | sed -E "s/^  ${label}: //"
+}
+
+run_one() {
+  local config="$1"
+  local label="$2"
+  local run_idx="$3"
+  local log="$LOG_DIR/${label}-run${run_idx}.log"
+
+  reset_target
+
+  local start end wall
+  start=$(date +%s.%N)
+  "$BINARY" -c "$config" run >"$log" 2>&1
+  end=$(date +%s.%N)
+  wall=$(awk -v s="$start" -v e="$end" 'BEGIN { printf "%.2f", e - s }')
+
+  local duration_raw throughput_raw rows_raw
+  duration_raw=$(parse_metric "$log" "Duration")
+  throughput_raw=$(parse_metric "$log" "Throughput")
+  rows_raw=$(parse_metric "$log" "Rows")
+
+  # Normalize: Duration "441.14s" -> 441.14; Throughput "43774 rows/sec" -> 43774;
+  # Rows "19310703" -> 19310703.
+  local duration throughput rows
+  duration=$(echo "$duration_raw" | grep -oE '^[0-9.]+' || echo "0")
+  throughput=$(echo "$throughput_raw" | grep -oE '^[0-9]+' || echo "0")
+  rows=$(echo "$rows_raw" | grep -oE '^[0-9]+' || echo "0")
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$label" "$run_idx" "$wall" "$duration" "$rows" "$throughput"
+}
+
+RESULTS_TSV="$LOG_DIR/results.tsv"
+printf 'config\trun\twall_sec\tdmt_duration_sec\trows\tthroughput_rows_per_sec\n' >"$RESULTS_TSV"
+
+# Warm-up: discard. Primes MSSQL buffer pool with the hot tables.
+echo ">>> warm-up (discarded)"
+run_one "$SCRIPT_DIR/benchmark-mssql-to-mysql-tuning-on.yaml" "warmup" "0" >/dev/null || true
+
+# Interleaved order: on/off/off/on/on/off => 3 observations per variant.
+ORDER=(
+  "tuning-on:1"
+  "tuning-off:1"
+  "tuning-off:2"
+  "tuning-on:2"
+  "tuning-on:3"
+  "tuning-off:3"
+)
+
+for entry in "${ORDER[@]}"; do
+  variant="${entry%%:*}"
+  idx="${entry##*:}"
+  config="$SCRIPT_DIR/benchmark-mssql-to-mysql-${variant}.yaml"
+  echo ">>> $variant run $idx"
+  row=$(run_one "$config" "$variant" "$idx")
+  echo "    $row"
+  echo "$row" >>"$RESULTS_TSV"
+done
+
+echo
+echo "Raw TSV: $RESULTS_TSV"
+echo
+
+# Markdown summary: median of each group.
+python3 - "$RESULTS_TSV" <<'PY'
+import csv, sys, statistics as s
+path = sys.argv[1]
+rows = [r for r in csv.DictReader(open(path), delimiter='\t')]
+by = {}
+for r in rows:
+    by.setdefault(r['config'], []).append(r)
+
+print("| config | n | median wall (s) | median dmt (s) | median rows/s | rows |")
+print("|---|---|---|---|---|---|")
+for cfg, rs in by.items():
+    walls = sorted(float(r['wall_sec']) for r in rs)
+    dmts = sorted(float(r['dmt_duration_sec']) for r in rs)
+    tps = sorted(int(r['throughput_rows_per_sec']) for r in rs)
+    rows = int(rs[0]['rows'])
+    print(f"| {cfg} | {len(rs)} | {s.median(walls):.2f} | {s.median(dmts):.2f} | {s.median(tps):,} | {rows:,} |")
+PY

--- a/scripts/bench-mysql-tuning.sh
+++ b/scripts/bench-mysql-tuning.sh
@@ -38,10 +38,22 @@ if [ ! -x "$BINARY" ]; then
   exit 1
 fi
 
-MYSQL_CMD=(docker exec -i mysql-target mysql -uroot -pTestPass2024 -N -B)
+# Local benchmark default only. Override with MYSQL_ROOT_PASSWORD if your
+# mysql-target container uses a different password. Passed via MYSQL_PWD in
+# the container env rather than on the mysql(1) command line so it doesn't
+# leak to the container's /proc/<pid>/cmdline.
+MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-TestPass2024}"
+MYSQL_CMD=(docker exec -i -e "MYSQL_PWD=$MYSQL_ROOT_PASSWORD" mysql-target mysql -uroot -N -B)
 
 reset_target() {
   "${MYSQL_CMD[@]}" -e "DROP DATABASE IF EXISTS stackoverflow_target; CREATE DATABASE stackoverflow_target CHARACTER SET utf8mb4;" 2>/dev/null
+}
+
+# Portable high-resolution wall clock in seconds. macOS/BSD `date` doesn't
+# support `%N`, so we reach for python3 which is present on every dev host
+# we build on.
+now_sec() {
+  python3 -c 'import time; print(time.time())'
 }
 
 # Parse dmt-rs's trailing summary block. Uses -a so ANSI color codes in the
@@ -62,9 +74,9 @@ run_one() {
   reset_target
 
   local start end wall
-  start=$(date +%s.%N)
+  start=$(now_sec)
   "$BINARY" -c "$config" run >"$log" 2>&1
-  end=$(date +%s.%N)
+  end=$(now_sec)
   wall=$(awk -v s="$start" -v e="$end" 'BEGIN { printf "%.2f", e - s }')
 
   local duration_raw throughput_raw rows_raw


### PR DESCRIPTION
## Summary

dmt-rs's first published **MySQL-target** benchmark. Prior numbers in the repo cover only MSSQL↔PostgreSQL. This PR:

- Adds `scripts/bench-mysql-tuning.sh` — a reproducer for the `mysql_bulk_session_tuning` A/B that was shipped in #111.
- Adds the two bench configs it consumes.
- Publishes `docs/mysql-baseline.md` with methodology and results.

## Unexpected finding

On dmt-rs's default config (no indexes, no FKs), **tuning loses 14%**:

| config | n | median wall (s) | median rows/s |
|---|---|---|---|
| `mysql_bulk_session_tuning: true`  | 3 | 427.14 | 45,227 |
| `mysql_bulk_session_tuning: false` | 3 | 365.42 | 52,864 |

Distributions do not overlap. Root cause is scope: `create_indexes: false` and `create_foreign_keys: false` are dmt-rs defaults, so neither `unique_checks=0` nor `foreign_key_checks=0` has anything to skip. InnoDB's change-buffer bookkeeping triggered by `unique_checks=0` appears to be pure overhead on this workload. Full analysis in `docs/mysql-baseline.md`.

This doesn't invalidate #111 — the tuning still helps on workloads that exercise its hot paths (index creation, FK creation). But it does suggest we may want to **flip the default to `false`** and only set the vars during finalization transactions. That's a separate PR after a follow-up benchmark with indexes + FKs enabled confirms the predicted win.

## Methodology

- Warm-up run discarded (primes MSSQL buffer pool).
- Interleaved variant order `on/off/off/on/on/off` so residual drift cannot align with a variant.
- Target DB dropped + recreated between every run.
- n=3 per variant; medians reported.

## Test plan

- [x] Parser dry-run against synthetic summary block — produces correct values.
- [x] End-to-end run completed (~45 min wall) — all 6 measurements have matching row counts (19,310,703).
- [x] `git status` clean after `.gitignore` excludes `.bench-logs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)