### PR TITLE
bench: full-schema follow-up — tuning effect is ambiguous

### DIFF
--- a/benchmark-mssql-to-mysql-full-tuning-off.yaml
+++ b/benchmark-mssql-to-mysql-full-tuning-off.yaml
@@ -1,0 +1,28 @@
+source:
+  type: mssql
+  host: localhost
+  port: 1433
+  database: StackOverflow2010
+  user: sa
+  password: "TestPass2024"
+  schema: dbo
+  encrypt: false
+  trust_server_cert: true
+
+target:
+  type: mysql
+  host: localhost
+  port: 3307
+  database: stackoverflow_target
+  schema: stackoverflow_target
+  user: root
+  password: "TestPass2024"
+  ssl_mode: disable
+
+migration:
+  target_mode: drop_recreate
+  workers: 4
+  chunk_size: 50000
+  mysql_bulk_session_tuning: false
+  create_indexes: true
+  create_foreign_keys: true

--- a/benchmark-mssql-to-mysql-full-tuning-on.yaml
+++ b/benchmark-mssql-to-mysql-full-tuning-on.yaml
@@ -1,0 +1,31 @@
+source:
+  type: mssql
+  host: localhost
+  port: 1433
+  database: StackOverflow2010
+  user: sa
+  password: "TestPass2024"
+  schema: dbo
+  encrypt: false
+  trust_server_cert: true
+
+target:
+  type: mysql
+  host: localhost
+  port: 3307
+  database: stackoverflow_target
+  schema: stackoverflow_target
+  user: root
+  password: "TestPass2024"
+  ssl_mode: disable
+
+migration:
+  target_mode: drop_recreate
+  workers: 4
+  chunk_size: 50000
+  mysql_bulk_session_tuning: true
+  # Unlike the baseline bench, this run exercises the paths the tuning was
+  # designed to optimize: FK validation scans during ADD CONSTRAINT, and
+  # secondary-index uniqueness enforcement during ALTER TABLE.
+  create_indexes: true
+  create_foreign_keys: true

--- a/docs/mysql-baseline.md
+++ b/docs/mysql-baseline.md
@@ -134,3 +134,92 @@ cat .bench-logs/results.tsv
 The script hard-codes 3 runs per variant in its `ORDER` array. To change
 the run count or sequence, edit that array in `scripts/bench-mysql-tuning.sh`.
 Override the MySQL test password with `MYSQL_ROOT_PASSWORD=...`.
+
+---
+
+## Follow-up: full-schema run (indexes + FKs enabled)
+
+The baseline above runs against dmt-rs's defaults — no secondary indexes,
+no foreign keys, so neither tuning variable has anything to skip. To
+actually stress the tuning's hot paths we re-ran the same A/B with
+`create_indexes: true` and `create_foreign_keys: true`, which forces
+`ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY` (child-table validation
+scan) and `ALTER TABLE ... ADD UNIQUE INDEX` (uniqueness enforcement)
+into the finalize phase where `foreign_key_checks=0` / `unique_checks=0`
+are designed to pay off.
+
+Configs: `benchmark-mssql-to-mysql-full-tuning-{on,off}.yaml`.
+Reproducer: `scripts/bench-mysql-full-schema.sh`. Methodology matches
+the baseline (discarded warm-up, interleaved order, n=3, medians).
+
+### Result — ambiguous, not confirming
+
+| config           | n | median wall (s) | median rows/s |
+|------------------|--:|---:|---:|
+| `full-tuning-on` | 3 | 393.48 | 49,099 |
+| `full-tuning-off`| 3 | 431.27 | 44,786 |
+
+Raw runs:
+
+| config          | run | wall (s) | dmt (s) | rows/s |
+|-----------------|-----|---------:|--------:|-------:|
+| full-tuning-on  | 1   | 393.48   | 393.30  | 49,099 |
+| full-tuning-off | 1   | 431.27   | 431.17  | 44,786 |
+| full-tuning-off | 2   | 457.63   | 457.50  | 42,209 |
+| full-tuning-on  | 2   | 435.52   | 435.33  | 44,358 |
+| full-tuning-on  | 3   | 385.31   | 385.20  | 50,131 |
+| full-tuning-off | 3   | 339.80   | 339.66  | 56,853 |
+
+Medians favor tuning-on by ~10%, but — unlike the baseline above, where
+every off-run was faster than every on-run — these distributions **do
+overlap**. The fastest tuning-off run (56,853 rows/s) beats every
+tuning-on run; the slowest tuning-off run (42,209) is slower than the
+slowest tuning-on (44,358). Put the six throughput values in a single
+sorted list and rank them by variant:
+
+```
+42209 (off) 44358 (on) 44786 (off) 49099 (on) 50131 (on) 56853 (off)
+```
+
+Rank sums are 10 (off) vs 11 (on) out of 21 total — essentially a coin
+flip. With n=3 per variant we cannot reject "no effect".
+
+### What we learned
+
+Combining this with the baseline:
+
+| config                                                  | outcome              | confidence |
+|---------------------------------------------------------|----------------------|------------|
+| defaults (`create_indexes: false`, FKs off)             | tuning **loses 14%** | distributions don't overlap |
+| full schema (`create_indexes: true`, `create_foreign_keys: true`) | tuning trends +10%   | distributions overlap; can't confirm |
+
+The 14% cost on defaults is real — that case is worth acting on. The
+full-schema gain is the right direction but not yet proven; we'd need
+a bigger n (maybe 10) or a schema with heavier FK/index density
+(StackOverflow2010 has very few secondary indexes in the source) to
+tighten the error bars.
+
+### Likely bigger lever: the MySQL container itself
+
+The target runs a stock `mysql:8.0` with a 128 MB InnoDB buffer pool
+against 19 M rows. That's almost certainly the dominant bottleneck —
+once the working set exceeds 128 MB, InnoDB thrashes, and any
+application-level tuning A/B becomes noise floating on top of I/O. A
+tuned container (2 GB buffer pool, 512 MB redo log, `doublewrite=OFF`,
+modern I/O capacity defaults) is probably a bigger speedup than
+anything we can do in application code, and would also give the
+session-tuning A/B a cleaner signal.
+
+That's tracked as the next follow-up; not in scope for this PR.
+
+### Recommendation re: the default
+
+Weak but leaning **flip the default to `false`**: the 14% cost on the
+common-case config is measured and real, while the gain on the
+full-schema config is not confirmed. A cleaner fix is to leave the
+default `false` and have the finalize phase set
+`foreign_key_checks = 0` inside the specific transactions that run
+`ADD CONSTRAINT FOREIGN KEY` / `ADD UNIQUE INDEX`, so the win is
+narrow-scoped to where it pays. That's a code change deferred to its
+own PR.
+

--- a/scripts/bench-mysql-full-schema.sh
+++ b/scripts/bench-mysql-full-schema.sh
@@ -25,10 +25,22 @@ if [ ! -x "$BINARY" ]; then
   exit 1
 fi
 
-MYSQL_CMD=(docker exec -i mysql-target mysql -uroot -pTestPass2024 -N -B)
+# Local benchmark default only. Override with MYSQL_ROOT_PASSWORD if your
+# mysql-target container uses a different password. Passed via MYSQL_PWD in
+# the container env rather than on the mysql(1) command line so it doesn't
+# leak to the container's /proc/<pid>/cmdline.
+MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-TestPass2024}"
+MYSQL_CMD=(docker exec -i -e "MYSQL_PWD=$MYSQL_ROOT_PASSWORD" mysql-target mysql -uroot -N -B)
 
 reset_target() {
   "${MYSQL_CMD[@]}" -e "DROP DATABASE IF EXISTS stackoverflow_target; CREATE DATABASE stackoverflow_target CHARACTER SET utf8mb4;" 2>/dev/null
+}
+
+# Portable high-resolution wall clock in seconds. macOS/BSD `date` doesn't
+# support `%N`, so we reach for python3 which is present on every dev host
+# we build on.
+now_sec() {
+  python3 -c 'import time; print(time.time())'
 }
 
 parse_metric() {
@@ -46,9 +58,9 @@ run_one() {
   reset_target
 
   local start end wall
-  start=$(date +%s.%N)
+  start=$(now_sec)
   "$BINARY" -c "$config" run >"$log" 2>&1
-  end=$(date +%s.%N)
+  end=$(now_sec)
   wall=$(awk -v s="$start" -v e="$end" 'BEGIN { printf "%.2f", e - s }')
 
   local duration_raw throughput_raw rows_raw

--- a/scripts/bench-mysql-full-schema.sh
+++ b/scripts/bench-mysql-full-schema.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# MySQL tuning A/B benchmark — full-schema variant.
+#
+# Same methodology as bench-mysql-tuning.sh, but migrates with
+# `create_indexes: true` and `create_foreign_keys: true` so that the
+# finalization phase (ADD CONSTRAINT FOREIGN KEY, ADD INDEX UNIQUE)
+# actually exercises the paths that `mysql_bulk_session_tuning` is
+# designed to optimize. See docs/mysql-baseline.md for why this matters.
+#
+# Expects:
+#   - mssql-bench    container running, StackOverflow2010 on :1433
+#   - mysql-target   container running, listening on :3307
+#   - ./target/release/dmt-rs built with --features mysql
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BINARY="$SCRIPT_DIR/target/release/dmt-rs"
+LOG_DIR="${LOG_DIR:-$SCRIPT_DIR/.bench-logs}"
+
+mkdir -p "$LOG_DIR"
+
+if [ ! -x "$BINARY" ]; then
+  echo "error: $BINARY not found. Build with: cargo build --release --features mysql" >&2
+  exit 1
+fi
+
+MYSQL_CMD=(docker exec -i mysql-target mysql -uroot -pTestPass2024 -N -B)
+
+reset_target() {
+  "${MYSQL_CMD[@]}" -e "DROP DATABASE IF EXISTS stackoverflow_target; CREATE DATABASE stackoverflow_target CHARACTER SET utf8mb4;" 2>/dev/null
+}
+
+parse_metric() {
+  local log="$1"
+  local label="$2"
+  grep -aE "^  ${label}: " "$log" | tail -1 | sed -E "s/^  ${label}: //"
+}
+
+run_one() {
+  local config="$1"
+  local label="$2"
+  local run_idx="$3"
+  local log="$LOG_DIR/${label}-run${run_idx}.log"
+
+  reset_target
+
+  local start end wall
+  start=$(date +%s.%N)
+  "$BINARY" -c "$config" run >"$log" 2>&1
+  end=$(date +%s.%N)
+  wall=$(awk -v s="$start" -v e="$end" 'BEGIN { printf "%.2f", e - s }')
+
+  local duration_raw throughput_raw rows_raw
+  duration_raw=$(parse_metric "$log" "Duration")
+  throughput_raw=$(parse_metric "$log" "Throughput")
+  rows_raw=$(parse_metric "$log" "Rows")
+
+  local duration throughput rows
+  duration=$(echo "$duration_raw" | grep -oE '^[0-9.]+' || echo "0")
+  throughput=$(echo "$throughput_raw" | grep -oE '^[0-9]+' || echo "0")
+  rows=$(echo "$rows_raw" | grep -oE '^[0-9]+' || echo "0")
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$label" "$run_idx" "$wall" "$duration" "$rows" "$throughput"
+}
+
+RESULTS_TSV="$LOG_DIR/results.tsv"
+printf 'config\trun\twall_sec\tdmt_duration_sec\trows\tthroughput_rows_per_sec\n' >"$RESULTS_TSV"
+
+echo ">>> warm-up (discarded)"
+run_one "$SCRIPT_DIR/benchmark-mssql-to-mysql-full-tuning-on.yaml" "warmup" "0" >/dev/null || true
+
+ORDER=(
+  "full-tuning-on:1"
+  "full-tuning-off:1"
+  "full-tuning-off:2"
+  "full-tuning-on:2"
+  "full-tuning-on:3"
+  "full-tuning-off:3"
+)
+
+for entry in "${ORDER[@]}"; do
+  variant="${entry%%:*}"
+  idx="${entry##*:}"
+  config="$SCRIPT_DIR/benchmark-mssql-to-mysql-${variant}.yaml"
+  echo ">>> $variant run $idx"
+  row=$(run_one "$config" "$variant" "$idx")
+  echo "    $row"
+  echo "$row" >>"$RESULTS_TSV"
+done
+
+echo
+echo "Raw TSV: $RESULTS_TSV"
+echo
+
+python3 - "$RESULTS_TSV" <<'PY'
+import csv, sys, statistics as s
+path = sys.argv[1]
+rows = [r for r in csv.DictReader(open(path), delimiter='\t')]
+by = {}
+for r in rows:
+    by.setdefault(r['config'], []).append(r)
+
+print("| config | n | median wall (s) | median dmt (s) | median rows/s | rows |")
+print("|---|---|---|---|---|---|")
+for cfg, rs in by.items():
+    walls = sorted(float(r['wall_sec']) for r in rs)
+    dmts = sorted(float(r['dmt_duration_sec']) for r in rs)
+    tps = sorted(int(r['throughput_rows_per_sec']) for r in rs)
+    rows = int(rs[0]['rows'])
+    print(f"| {cfg} | {len(rs)} | {s.median(walls):.2f} | {s.median(dmts):.2f} | {s.median(tps):,} | {rows:,} |")
+PY


### PR DESCRIPTION
## Summary

Second A/B run promised in #113: same dataset, same methodology, but with `create_indexes: true` + `create_foreign_keys: true` so the finalize phase actually exercises the `ADD CONSTRAINT FOREIGN KEY` and `ADD UNIQUE INDEX` paths that tuning is designed to optimize.

**Result: medians favor tuning-on by ~10%, but distributions overlap — not confirming.**

| config | n | median wall (s) | median rows/s |
|---|---|---|---|
| `full-tuning-on`  | 3 | 393.48 | 49,099 |
| `full-tuning-off` | 3 | 431.27 | 44,786 |

Unlike #113's baseline where every off-run beat every on-run, the six throughput values interleave (sorted: off / on / off / on / on / off — rank sums 10 vs 11 of 21). With n=3 per variant we cannot reject "no effect".

## Combined findings

| config | outcome | confidence |
|---|---|---|
| defaults (no indexes/FKs) | tuning **loses 14 %** | distributions don't overlap |
| full schema              | tuning trends **+10 %** | distributions overlap; unconfirmed |

The 14 % cost on defaults is real and acted-on-able. The full-schema gain is the right direction but not proven — tightening it would need either bigger n (≈10) or a schema with heavier FK/index density. StackOverflow2010 has very few secondary indexes.

## Recommendation (deferred to its own PR)

Lean toward flipping `mysql_bulk_session_tuning`'s default to `false` and having finalize set the vars to 0 only inside the transactions that run `ADD CONSTRAINT FOREIGN KEY` / `ADD UNIQUE INDEX`. That way the narrow win is preserved and the broad loss on the common case goes away.

## Likely bigger lever

The target runs a stock `mysql:8.0` container with a **128 MB** InnoDB buffer pool against 19 M rows. Any application-level tuning A/B is almost certainly noise on top of buffer-pool thrashing. A tuned container (2 GB buffer pool, 512 MB redo, `doublewrite=OFF`, modern I/O capacity) is probably a bigger speedup than any code change and would also give future A/B benches a cleaner signal. Next step, separate PR.

## Depends on

Branches off #113 (`bench/mysql-baseline`). When #113 merges, this auto-rebases onto the squashed commit. If #113 is merged first, merging this is a noop diff for any shared files.

## Test plan

- [x] `bash -n scripts/bench-mysql-full-schema.sh` (syntax)
- [x] End-to-end run completed (~50 min wall) — all 6 measurements have matching row counts (19,310,703)
- [x] No new code in this PR (configs + script + doc only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)