### PR TITLE
bench(mysql): LOAD DATA re-validated on tuned container — still loses

### DIFF
--- a/benchmark-mssql-to-mysql-load-data-off.yaml
+++ b/benchmark-mssql-to-mysql-load-data-off.yaml
@@ -1,0 +1,29 @@
+source:
+  type: mssql
+  host: localhost
+  port: 1433
+  database: StackOverflow2010
+  user: sa
+  password: "TestPass2024"
+  schema: dbo
+  encrypt: false
+  trust_server_cert: true
+
+target:
+  type: mysql
+  host: localhost
+  port: 3307
+  database: stackoverflow_target
+  schema: stackoverflow_target
+  user: root
+  password: "TestPass2024"
+  ssl_mode: disable
+
+migration:
+  target_mode: drop_recreate
+  workers: 4
+  chunk_size: 50000
+  # Session tuning on (dmt-rs default) — not what we're measuring.
+  mysql_bulk_session_tuning: true
+  # The lever under test: INSERT path.
+  mysql_load_data: never

--- a/benchmark-mssql-to-mysql-load-data-on.yaml
+++ b/benchmark-mssql-to-mysql-load-data-on.yaml
@@ -1,0 +1,30 @@
+source:
+  type: mssql
+  host: localhost
+  port: 1433
+  database: StackOverflow2010
+  user: sa
+  password: "TestPass2024"
+  schema: dbo
+  encrypt: false
+  trust_server_cert: true
+
+target:
+  type: mysql
+  host: localhost
+  port: 3307
+  database: stackoverflow_target
+  schema: stackoverflow_target
+  user: root
+  password: "TestPass2024"
+  ssl_mode: disable
+
+migration:
+  target_mode: drop_recreate
+  workers: 4
+  chunk_size: 50000
+  # Session tuning on (dmt-rs default) — not what we're measuring.
+  mysql_bulk_session_tuning: true
+  # The lever under test: LOAD DATA LOCAL INFILE path.
+  # Requires `local_infile = 1` on the target. The tuned my.cnf sets this.
+  mysql_load_data: always

--- a/docs/mysql-performance-tuning.md
+++ b/docs/mysql-performance-tuning.md
@@ -23,6 +23,17 @@ Tables with large text columns (TEXT, LONGTEXT, nvarchar(max)) are significantly
 
 ## LOAD DATA LOCAL INFILE
 
+> **Note (2026-04):** the numbers in this section were collected on a
+> stock `mysql:8.0` container. The finding that LOAD DATA loses at
+> ≥2 workers has since been re-validated on the tuned container
+> (`docker/mysql-target/my.cnf`, 2 GB buffer pool, all the knobs from
+> `docs/mysql-target-container.md`). On the tuned container,
+> `mysql_load_data: always` was still ~12 % slower than batched
+> INSERT at 4 workers — distributions do not overlap. TSV-generation
+> CPU cost is the dominant factor regardless of I/O tier. See the
+> "LOAD DATA LOCAL INFILE, re-evaluated on the tuned container"
+> section in `docs/mysql-target-container.md` for the re-test data.
+
 ### Configuration
 
 ```yaml

--- a/docs/mysql-target-container.md
+++ b/docs/mysql-target-container.md
@@ -91,11 +91,58 @@ this host:
 
 The structural reason is protocol: Postgres has `COPY ... FROM BINARY`
 and MSSQL has BCP — both are binary bulk protocols. MySQL has no
-public equivalent; dmt-rs currently uses multi-row **text** INSERT with
-`?` placeholders (capped at 65,535 placeholders per statement = ~3 K
-rows per batch for a 20-column table). Getting onto mysql_async's
-binary prepared-statement protocol is the next lever; tracked as a
-follow-up.
+public equivalent; dmt-rs currently uses multi-row INSERT with `?`
+placeholders (capped at 65,535 placeholders per statement = ~3 K rows
+per batch for a 20-column table). Note that mysql_async's `exec_drop`
+already sends values in the **binary** protocol — only the SQL
+template is text. We initially thought moving to
+`Queryable::exec_batch` (server-side prepared, one exec per row) would
+help, but that API does one round-trip per row, which on a 19 M-row
+dataset would dwarf any CPU savings. So that lever is not on the
+table via the current mysql_async surface.
+
+## LOAD DATA LOCAL INFILE, re-evaluated on the tuned container
+
+`docs/mysql-performance-tuning.md` had previously concluded that LOAD
+DATA loses to multi-row INSERT at ≥2 workers because client-side TSV
+generation is CPU-expensive. That finding was on stock `mysql:8.0`
+where the InnoDB I/O path was the bottleneck; we wanted to re-check
+on the tuned container where I/O is no longer the gate, in case the
+TSV CPU cost was previously masked.
+
+It wasn't. LOAD DATA is still slower on the tuned container:
+
+| config (session tuning on, 4 workers)  | n | median wall (s) | median rows/s |
+|----------------------------------------|---|----------------:|--------------:|
+| `mysql_load_data: never` (INSERT)      | 3 | 162.63          | 118,874       |
+| `mysql_load_data: always` (LOAD DATA)  | 3 | 184.06          | 105,020       |
+
+Raw runs:
+
+| run | config                 | wall (s) | rows/s  |
+|-----|------------------------|---------:|--------:|
+| 1   | load-data-off (INSERT) | 158.10   | 122,267 |
+| 1   | load-data-on           | 177.89   | 108,623 |
+| 2   | load-data-on           | 184.06   | 105,020 |
+| 2   | load-data-off          | 162.63   | 118,874 |
+| 3   | load-data-off          | 166.38   | 116,167 |
+| 3   | load-data-on           | 187.35   | 103,157 |
+
+Every INSERT run beat every LOAD DATA run — distributions don't
+overlap. LOAD DATA is ~12 % slower on the tuned container.
+
+The CPU cost of client-side TSV escape-handling (every `\t`, `\n`,
+`\\`, `\0`, NULL sentinel per value per row — see `escape_tsv_value`
+in `crates/dmt-rs/src/drivers/mysql/writer.rs:371`) still outweighs
+any server-side bulk-path win with 4 concurrent writers. We're
+leaving `mysql_load_data: never` as the default; the feature is
+retained for single-worker configs and for users whose workload
+profile differs.
+
+Conclusion for MySQL target throughput on this host: we appear to be
+near the practical ceiling of the INSERT path. Further gains likely
+require either more buffer-pool RAM (to speed PK rebuild, which is
+~60 % of each run's time) or a protocol dmt-rs doesn't yet use.
 
 ## Reproducing
 
@@ -115,4 +162,5 @@ docker run -d \
 cargo build --release --features mysql
 LOG_DIR=.bench-logs-tuned-baseline    ./scripts/bench-mysql-tuning.sh
 LOG_DIR=.bench-logs-tuned-full-schema ./scripts/bench-mysql-full-schema.sh
+LOG_DIR=.bench-logs-load-data         ./scripts/bench-mysql-load-data.sh
 ```

--- a/scripts/bench-mysql-load-data.sh
+++ b/scripts/bench-mysql-load-data.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# MySQL LOAD DATA LOCAL INFILE vs multi-row INSERT A/B benchmark.
+#
+# Ran against the TUNED mysql-target container (docker/mysql-target/my.cnf).
+# Purpose: re-evaluate docs/mysql-performance-tuning.md's finding that LOAD
+# DATA loses at >=2 workers. That finding was on stock mysql:8.0 with a
+# 128 MB buffer pool, where I/O was the bottleneck and TSV-generation CPU
+# was secondary. On the tuned container I/O is no longer the gate, so this
+# bench re-measures whether LOAD DATA's zero-per-row-SQL-overhead advantage
+# now beats the INSERT path's CPU-efficient path.
+#
+# Same methodology as bench-mysql-tuning.sh: warm-up discard, interleaved
+# variant order, target DB dropped between runs, n=3 per variant, median
+# reported.
+#
+# Expects:
+#   - mssql-bench      running, StackOverflow2010 on :1433
+#   - mysql-target     running, tuned my.cnf mounted, :3307
+#   - ./target/release/dmt-rs built with --features mysql
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BINARY="$SCRIPT_DIR/target/release/dmt-rs"
+LOG_DIR="${LOG_DIR:-$SCRIPT_DIR/.bench-logs-load-data}"
+
+mkdir -p "$LOG_DIR"
+
+if [ ! -x "$BINARY" ]; then
+  echo "error: $BINARY not found. Build with: cargo build --release --features mysql" >&2
+  exit 1
+fi
+
+# Local benchmark default only. Override with MYSQL_ROOT_PASSWORD if your
+# mysql-target container uses a different password.
+MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD:-TestPass2024}"
+MYSQL_CMD=(docker exec -i -e "MYSQL_PWD=$MYSQL_ROOT_PASSWORD" mysql-target mysql -uroot -N -B)
+
+reset_target() {
+  "${MYSQL_CMD[@]}" -e "DROP DATABASE IF EXISTS stackoverflow_target; CREATE DATABASE stackoverflow_target CHARACTER SET utf8mb4;" 2>/dev/null
+}
+
+# Portable high-resolution wall clock. macOS/BSD `date` doesn't support `%N`.
+now_sec() {
+  python3 -c 'import time; print(time.time())'
+}
+
+parse_metric() {
+  local log="$1"
+  local label="$2"
+  grep -aE "^  ${label}: " "$log" | tail -1 | sed -E "s/^  ${label}: //"
+}
+
+run_one() {
+  local config="$1"
+  local label="$2"
+  local run_idx="$3"
+  local log="$LOG_DIR/${label}-run${run_idx}.log"
+
+  reset_target
+
+  local start end wall
+  start=$(now_sec)
+  "$BINARY" -c "$config" run >"$log" 2>&1
+  end=$(now_sec)
+  wall=$(awk -v s="$start" -v e="$end" 'BEGIN { printf "%.2f", e - s }')
+
+  local duration_raw throughput_raw rows_raw
+  duration_raw=$(parse_metric "$log" "Duration")
+  throughput_raw=$(parse_metric "$log" "Throughput")
+  rows_raw=$(parse_metric "$log" "Rows")
+
+  local duration throughput rows
+  duration=$(echo "$duration_raw" | grep -oE '^[0-9.]+' || echo "0")
+  throughput=$(echo "$throughput_raw" | grep -oE '^[0-9]+' || echo "0")
+  rows=$(echo "$rows_raw" | grep -oE '^[0-9]+' || echo "0")
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$label" "$run_idx" "$wall" "$duration" "$rows" "$throughput"
+}
+
+RESULTS_TSV="$LOG_DIR/results.tsv"
+printf 'config\trun\twall_sec\tdmt_duration_sec\trows\tthroughput_rows_per_sec\n' >"$RESULTS_TSV"
+
+echo ">>> warm-up (discarded)"
+run_one "$SCRIPT_DIR/benchmark-mssql-to-mysql-load-data-off.yaml" "warmup" "0" >/dev/null || true
+
+ORDER=(
+  "load-data-off:1"
+  "load-data-on:1"
+  "load-data-on:2"
+  "load-data-off:2"
+  "load-data-off:3"
+  "load-data-on:3"
+)
+
+for entry in "${ORDER[@]}"; do
+  variant="${entry%%:*}"
+  idx="${entry##*:}"
+  config="$SCRIPT_DIR/benchmark-mssql-to-mysql-${variant}.yaml"
+  echo ">>> $variant run $idx"
+  row=$(run_one "$config" "$variant" "$idx")
+  echo "    $row"
+  echo "$row" >>"$RESULTS_TSV"
+done
+
+echo
+echo "Raw TSV: $RESULTS_TSV"
+echo
+
+python3 - "$RESULTS_TSV" <<'PY'
+import csv, sys, statistics as s
+path = sys.argv[1]
+rows = [r for r in csv.DictReader(open(path), delimiter='\t')]
+by = {}
+for r in rows:
+    by.setdefault(r['config'], []).append(r)
+
+print("| config | n | median wall (s) | median dmt (s) | median rows/s | rows |")
+print("|---|---|---|---|---|---|")
+for cfg, rs in by.items():
+    walls = sorted(float(r['wall_sec']) for r in rs)
+    dmts = sorted(float(r['dmt_duration_sec']) for r in rs)
+    tps = sorted(int(r['throughput_rows_per_sec']) for r in rs)
+    rows = int(rs[0]['rows'])
+    print(f"| {cfg} | {len(rs)} | {s.median(walls):.2f} | {s.median(dmts):.2f} | {s.median(tps):,} | {rows:,} |")
+PY


### PR DESCRIPTION
## Summary

Re-ran the LOAD DATA LOCAL INFILE vs multi-row INSERT A/B on the tuned container (shipped in #115) to test whether `mysql_bulk_session_tuning`-style retuning changed the conclusion. It didn't.

| config                              | n | median wall (s) | median rows/s |
|-------------------------------------|--:|---:|---:|
| `mysql_load_data: never` (INSERT)   | 3 | 162.63 | 118,874 |
| `mysql_load_data: always` (LOAD DATA) | 3 | 184.06 | 105,020 |

Every INSERT run beat every LOAD DATA run — distributions don't overlap. LOAD DATA is ~12% slower across the board. Client-side TSV-escape CPU cost dominates at 4 concurrent writers regardless of I/O tier.

## Why this PR

Two open questions from the survey/PR #115 discussion:

1. **"Would LOAD DATA now win on the tuned container?"** — original `docs/mysql-performance-tuning.md` concluded it loses at ≥2 workers on stock MySQL; we wanted to confirm that finding wasn't a stock-container artifact. Answer: it wasn't. LOAD DATA is slower at both I/O tiers.
2. **"Would mysql_async's `exec_batch` (binary prepared INSERT) be the next lever?"** — reading the crate source (`queryable/mod.rs:518`) showed `exec_batch` does one round-trip per row. For a 19 M-row dataset that's 3+ orders of magnitude more round-trips than our current multi-row INSERT, almost certainly a regression. `exec_drop` already sends values in the binary protocol; only the SQL template is text. So that lever is not on the table via the current mysql_async surface. Doc updated to reflect this.

## What's in the PR

- `benchmark-mssql-to-mysql-load-data-{on,off}.yaml` — the two A/B configs
- `scripts/bench-mysql-load-data.sh` — bench runner, same methodology as `bench-mysql-tuning.sh`
- `docs/mysql-target-container.md` — new "LOAD DATA LOCAL INFILE, re-evaluated on the tuned container" section with the numbers; earlier optimistic note about exec_batch removed
- `docs/mysql-performance-tuning.md` — cross-reference note pointing at the re-validation

## Next lever

Finalize-phase PK rebuild is ~60% of each run's time and is RAM-bound. The tuned container has `--memory=6g` but the pool is only 2 GB — 4 GB of container RAM is unused. Bumping `innodb_buffer_pool_size` to 4 GB within the existing 6 GB cap should directly help PK rebuild without touching the VM. Queued as a follow-up.

## Test plan

- [x] `bash -n scripts/bench-mysql-load-data.sh`
- [x] End-to-end bench completed, 6/6 runs with matching row counts (19,310,703)
- [x] Container pair (`mssql-target` + `mssql-bench`) restored at end of bench
- [x] No code changes, only configs + script + docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)