### PR TITLE
feat(ai): error diagnosis for DDL failures

### DIFF
--- a/crates/dmt-rs/src/ai/errordiag.rs
+++ b/crates/dmt-rs/src/ai/errordiag.rs
@@ -45,7 +45,10 @@ pub struct ErrorContext {
     pub target_mode: String,
 }
 
-/// AI error diagnoser. Caches results by SHA-256 of the error message.
+/// AI error diagnoser. Caches results by a 128-bit truncated SHA-256 of
+/// the error message (parity with Go dmt's `digest[:16]`). The truncation
+/// is intentional: 128 bits of collision resistance is ample for an
+/// in-process dedup cache where keys are short error strings.
 pub struct ErrorDiagnoser {
     provider: Arc<dyn AiProviderClient>,
     cache: RwLock<HashMap<String, ErrorDiagnosis>>,
@@ -117,9 +120,14 @@ pub fn set_diagnosis_handler(handler: Option<DiagnosisHandler>) {
 }
 
 /// Dispatch a diagnosis to the registered handler, or log it as fallback.
+///
+/// The handler is cloned out of the lock before invocation so that a
+/// handler which calls [`set_diagnosis_handler`] (or otherwise needs the
+/// write lock) cannot deadlock, and so the read lock isn't held for the
+/// duration of handler execution.
 pub fn emit_diagnosis(diag: &ErrorDiagnosis) {
-    let guard = handler_slot().read().unwrap();
-    if let Some(h) = guard.as_ref() {
+    let handler = handler_slot().read().unwrap().clone();
+    if let Some(h) = handler {
         h(diag);
     } else {
         warn!("\n{}", diag.format_boxed());
@@ -241,12 +249,20 @@ fn parse_response(raw: &str) -> Result<ErrorDiagnosis> {
     Ok(diag)
 }
 
+/// Char-boundary-safe truncation. Byte-slicing with `&s[..max]` can panic
+/// on non-ASCII input if `max` falls inside a multi-byte UTF-8 sequence,
+/// so we walk `char_indices` and stop at the last char that fits.
 fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
-        s.to_string()
-    } else {
-        format!("{}...", &s[..max])
+        return s.to_string();
     }
+    let end = s
+        .char_indices()
+        .map(|(i, ch)| i + ch.len_utf8())
+        .take_while(|&end| end <= max)
+        .last()
+        .unwrap_or(0);
+    format!("{}...", &s[..end])
 }
 
 impl ErrorDiagnosis {
@@ -276,20 +292,13 @@ impl ErrorDiagnosis {
         let mut out = String::new();
 
         let write_padded = |out: &mut String, content: &str| {
-            let (inner_max, truncated);
-            if content.len() > width - 4 {
-                inner_max = width - 7;
-                truncated = format!("{}...", &content[..inner_max]);
+            let truncated = if content.len() > width - 4 {
+                truncate(content, width - 7)
             } else {
-                truncated = content.to_string();
-            }
-            let padding = width.saturating_sub(4 + truncated.len());
-            let _ = writeln!(
-                out,
-                "│ {}{} │",
-                truncated,
-                " ".repeat(padding)
-            );
+                content.to_string()
+            };
+            let padding = width.saturating_sub(4 + truncated.chars().count());
+            let _ = writeln!(out, "│ {}{} │", truncated, " ".repeat(padding));
         };
 
         let title = " AI Error Diagnosis ";
@@ -324,6 +333,32 @@ impl ErrorDiagnosis {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes tests that mutate the global diagnosis handler so they
+    /// don't trip over each other under `cargo test`'s default parallelism.
+    static HANDLER_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    /// RAII guard that captures the current global handler on construction
+    /// and restores it on drop, so a test can install a handler without
+    /// leaking state into sibling tests.
+    struct HandlerGuard {
+        prev: Option<DiagnosisHandler>,
+    }
+
+    impl HandlerGuard {
+        fn new() -> Self {
+            Self {
+                prev: handler_slot().read().unwrap().clone(),
+            }
+        }
+    }
+
+    impl Drop for HandlerGuard {
+        fn drop(&mut self) {
+            *handler_slot().write().unwrap() = self.prev.take();
+        }
+    }
 
     #[test]
     fn parses_clean_json() {
@@ -407,6 +442,9 @@ mod tests {
     #[test]
     fn handler_callback_fires_when_registered() {
         use std::sync::atomic::{AtomicUsize, Ordering};
+        let _serial = HANDLER_TEST_LOCK.lock().unwrap();
+        let _guard = HandlerGuard::new();
+
         let counter = Arc::new(AtomicUsize::new(0));
         let c = counter.clone();
         set_diagnosis_handler(Some(Arc::new(move |_: &ErrorDiagnosis| {
@@ -421,7 +459,17 @@ mod tests {
         };
         emit_diagnosis(&d);
         assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
 
-        set_diagnosis_handler(None);
+    #[test]
+    fn truncate_handles_multibyte_chars() {
+        // "caf\u{00e9}" — e-acute is 2 bytes UTF-8. Truncating at max=4 would
+        // panic on byte-slicing mid-sequence; char-safe version must stop at 3.
+        let s = "caf\u{00e9}";
+        assert_eq!(s.len(), 5);
+        let t = truncate(s, 4);
+        // Result is "caf..." — the e-acute doesn't fit in 4 bytes after "caf".
+        assert!(t.starts_with("caf"));
+        assert!(t.ends_with("..."));
     }
 }

--- a/crates/dmt-rs/src/ai/errordiag.rs
+++ b/crates/dmt-rs/src/ai/errordiag.rs
@@ -1,0 +1,427 @@
+//! AI-powered error diagnosis.
+//!
+//! Mirrors the Go `dmt` error-diagnosis feature
+//! (`internal/driver/ai_errordiag.go`). When a migration fails during DDL
+//! creation or data transfer, the caught error is sent to the configured
+//! LLM with schema context; the structured response (root cause +
+//! suggestions + confidence + category) is cached by error-message hash
+//! and emitted through a pluggable handler.
+//!
+//! Activation: whenever AI is configured. No separate CLI flag — parity
+//! with Go dmt, which gates on `aiMapper != nil`.
+
+use crate::ai::provider::AiProviderClient;
+use crate::core::schema::Column;
+use crate::error::{MigrateError, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::sync::{Arc, OnceLock, RwLock};
+use tracing::{debug, warn};
+
+/// AI-generated analysis of a migration error.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorDiagnosis {
+    /// Root cause (1–2 sentences).
+    pub cause: String,
+    /// Actionable fixes, ordered by likely effectiveness.
+    pub suggestions: Vec<String>,
+    /// `high` | `medium` | `low`.
+    pub confidence: String,
+    /// `type_mismatch` | `constraint` | `permission` | `connection` | `data_quality` | `other`.
+    pub category: String,
+}
+
+/// Context passed to the diagnoser for a single error.
+#[derive(Debug, Clone, Default)]
+pub struct ErrorContext {
+    pub error_message: String,
+    pub table_name: String,
+    pub table_schema: String,
+    pub columns: Vec<Column>,
+    pub source_db_type: String,
+    pub target_db_type: String,
+    pub target_mode: String,
+}
+
+/// AI error diagnoser. Caches results by SHA-256 of the error message.
+pub struct ErrorDiagnoser {
+    provider: Arc<dyn AiProviderClient>,
+    cache: RwLock<HashMap<String, ErrorDiagnosis>>,
+}
+
+impl ErrorDiagnoser {
+    pub fn new(provider: Arc<dyn AiProviderClient>) -> Self {
+        Self {
+            provider,
+            cache: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Analyze an error and return a structured diagnosis.
+    pub async fn diagnose(&self, ctx: &ErrorContext) -> Result<ErrorDiagnosis> {
+        let key = hash_error(&ctx.error_message);
+
+        if let Some(cached) = self.cache.read().unwrap().get(&key).cloned() {
+            debug!("AI error diagnosis: cache hit for error hash {}", &key[..8]);
+            return Ok(cached);
+        }
+
+        let (system, user) = build_prompt(ctx);
+
+        debug!(
+            "AI error diagnosis: analyzing error for table {}.{}",
+            ctx.table_schema, ctx.table_name
+        );
+
+        let raw = self
+            .provider
+            .complete_text(&system, &user, 1024)
+            .await
+            .map_err(|e| MigrateError::Config(format!("AI diagnosis failed: {}", e)))?;
+
+        let diagnosis = parse_response(&raw)?;
+
+        debug!(
+            "AI error diagnosis: category={}, confidence={}",
+            diagnosis.category, diagnosis.confidence
+        );
+
+        self.cache.write().unwrap().insert(key, diagnosis.clone());
+        Ok(diagnosis)
+    }
+
+    pub fn cache_size(&self) -> usize {
+        self.cache.read().unwrap().len()
+    }
+
+    pub fn clear_cache(&self) {
+        self.cache.write().unwrap().clear();
+    }
+}
+
+/// Handler callback for diagnosis output. The TUI registers one to render
+/// diagnoses as boxed messages; the CLI falls back to logging.
+pub type DiagnosisHandler = Arc<dyn Fn(&ErrorDiagnosis) + Send + Sync>;
+
+fn handler_slot() -> &'static RwLock<Option<DiagnosisHandler>> {
+    static SLOT: OnceLock<RwLock<Option<DiagnosisHandler>>> = OnceLock::new();
+    SLOT.get_or_init(|| RwLock::new(None))
+}
+
+/// Register a callback to receive diagnosis events. Pass `None` to
+/// unregister and fall back to logging.
+pub fn set_diagnosis_handler(handler: Option<DiagnosisHandler>) {
+    *handler_slot().write().unwrap() = handler;
+}
+
+/// Dispatch a diagnosis to the registered handler, or log it as fallback.
+pub fn emit_diagnosis(diag: &ErrorDiagnosis) {
+    let guard = handler_slot().read().unwrap();
+    if let Some(h) = guard.as_ref() {
+        h(diag);
+    } else {
+        warn!("\n{}", diag.format_boxed());
+    }
+}
+
+fn hash_error(msg: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(msg.as_bytes());
+    let digest = hasher.finalize();
+    hex::encode(&digest[..16])
+}
+
+fn build_prompt(ctx: &ErrorContext) -> (String, String) {
+    let system = "You are a database migration error analyst. Analyze the given \
+                  error and return ONLY a JSON object with fields: cause (string, \
+                  1-2 sentences), suggestions (array of 2-3 actionable strings), \
+                  confidence (\"high\"|\"medium\"|\"low\"), category \
+                  (\"type_mismatch\"|\"constraint\"|\"permission\"|\"connection\"|\"data_quality\"|\"other\"). \
+                  No markdown, no prose outside the JSON."
+        .to_string();
+
+    let mut user = String::new();
+    let _ = writeln!(user, "=== ERROR ===");
+    let _ = writeln!(user, "{}", ctx.error_message);
+    let _ = writeln!(user);
+    let _ = writeln!(user, "=== CONTEXT ===");
+    let _ = writeln!(user, "Source DB: {}", ctx.source_db_type);
+    let _ = writeln!(user, "Target DB: {}", ctx.target_db_type);
+    let _ = writeln!(
+        user,
+        "Table: {}.{}",
+        ctx.table_schema, ctx.table_name
+    );
+    if !ctx.target_mode.is_empty() {
+        let _ = writeln!(user, "Mode: {}", ctx.target_mode);
+    }
+
+    if !ctx.columns.is_empty() {
+        let _ = writeln!(user);
+        let _ = writeln!(user, "Columns (name: source_type):");
+        let max_cols = 20;
+        for (i, col) in ctx.columns.iter().enumerate() {
+            if i >= max_cols {
+                let _ = writeln!(
+                    user,
+                    "  ... and {} more columns",
+                    ctx.columns.len() - max_cols
+                );
+                break;
+            }
+            let type_str = if col.max_length > 0 {
+                format!("{}({})", col.data_type, col.max_length)
+            } else if col.precision > 0 && col.scale > 0 {
+                format!("{}({},{})", col.data_type, col.precision, col.scale)
+            } else if col.precision > 0 {
+                format!("{}({})", col.data_type, col.precision)
+            } else {
+                col.data_type.clone()
+            };
+            let nullable = if col.is_nullable { "" } else { " NOT NULL" };
+            let _ = writeln!(user, "  {}: {}{}", col.name, type_str, nullable);
+        }
+    }
+
+    let _ = writeln!(user);
+    let _ = writeln!(user, "=== OUTPUT ===");
+    user.push_str(
+        r#"Respond with ONLY a JSON object (no markdown, no explanation):
+{
+  "cause": "brief root cause explanation (1-2 sentences)",
+  "suggestions": ["actionable fix 1", "actionable fix 2", "actionable fix 3"],
+  "confidence": "high|medium|low",
+  "category": "type_mismatch|constraint|permission|connection|data_quality|other"
+}"#,
+    );
+
+    (system, user)
+}
+
+fn parse_response(raw: &str) -> Result<ErrorDiagnosis> {
+    let cleaned = raw
+        .trim()
+        .trim_start_matches("```json")
+        .trim_start_matches("```")
+        .trim_end_matches("```")
+        .trim();
+
+    let mut diag: ErrorDiagnosis = serde_json::from_str(cleaned).map_err(|e| {
+        MigrateError::Config(format!(
+            "invalid AI diagnosis JSON: {} (response: {})",
+            e,
+            truncate(cleaned, 100)
+        ))
+    })?;
+
+    if diag.cause.trim().is_empty() {
+        return Err(MigrateError::Config(
+            "AI diagnosis missing 'cause' field".into(),
+        ));
+    }
+    if diag.suggestions.is_empty() {
+        return Err(MigrateError::Config(
+            "AI diagnosis missing 'suggestions' field".into(),
+        ));
+    }
+
+    diag.confidence = match diag.confidence.to_ascii_lowercase().as_str() {
+        "high" | "medium" | "low" => diag.confidence.to_ascii_lowercase(),
+        _ => "medium".to_string(),
+    };
+    diag.category = match diag.category.to_ascii_lowercase().as_str() {
+        "type_mismatch" | "constraint" | "permission" | "connection" | "data_quality" | "other" => {
+            diag.category.to_ascii_lowercase()
+        }
+        _ => "other".to_string(),
+    };
+
+    Ok(diag)
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max])
+    }
+}
+
+impl ErrorDiagnosis {
+    /// Plain text rendering.
+    pub fn format(&self) -> String {
+        let mut out = String::new();
+        let _ = writeln!(out, "AI Error Diagnosis");
+        let _ = writeln!(out);
+        let _ = writeln!(out, "Cause: {}", self.cause);
+        let _ = writeln!(out);
+        let _ = writeln!(out, "Suggestions:");
+        for (i, s) in self.suggestions.iter().enumerate() {
+            let _ = writeln!(out, "  {}. {}", i + 1, s);
+        }
+        let _ = writeln!(out);
+        let _ = writeln!(
+            out,
+            "Confidence: {}  |  Category: {}",
+            self.confidence, self.category
+        );
+        out
+    }
+
+    /// Unicode-boxed rendering, 72 chars wide. Matches Go dmt FormatBox().
+    pub fn format_boxed(&self) -> String {
+        let width = 72usize;
+        let mut out = String::new();
+
+        let write_padded = |out: &mut String, content: &str| {
+            let (inner_max, truncated);
+            if content.len() > width - 4 {
+                inner_max = width - 7;
+                truncated = format!("{}...", &content[..inner_max]);
+            } else {
+                truncated = content.to_string();
+            }
+            let padding = width.saturating_sub(4 + truncated.len());
+            let _ = writeln!(
+                out,
+                "│ {}{} │",
+                truncated,
+                " ".repeat(padding)
+            );
+        };
+
+        let title = " AI Error Diagnosis ";
+        let left_pad = (width - 2 - title.len()) / 2;
+        let right_pad = width - 2 - title.len() - left_pad;
+        let _ = writeln!(
+            out,
+            "┌{}{}{}┐",
+            "─".repeat(left_pad),
+            title,
+            "─".repeat(right_pad)
+        );
+
+        write_padded(&mut out, "");
+        write_padded(&mut out, &format!("Cause: {}", self.cause));
+        write_padded(&mut out, "");
+        write_padded(&mut out, "Suggestions:");
+        for (i, s) in self.suggestions.iter().enumerate() {
+            write_padded(&mut out, &format!("  {}. {}", i + 1, s));
+        }
+        write_padded(&mut out, "");
+        write_padded(
+            &mut out,
+            &format!("Confidence: {}  |  Category: {}", self.confidence, self.category),
+        );
+
+        let _ = write!(out, "└{}┘", "─".repeat(width - 2));
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_clean_json() {
+        let raw = r#"{"cause":"x","suggestions":["a","b"],"confidence":"HIGH","category":"TYPE_MISMATCH"}"#;
+        let d = parse_response(raw).unwrap();
+        assert_eq!(d.cause, "x");
+        assert_eq!(d.suggestions, vec!["a", "b"]);
+        assert_eq!(d.confidence, "high");
+        assert_eq!(d.category, "type_mismatch");
+    }
+
+    #[test]
+    fn parses_markdown_fenced_json() {
+        let raw = "```json\n{\"cause\":\"c\",\"suggestions\":[\"s1\"],\"confidence\":\"low\",\"category\":\"other\"}\n```";
+        let d = parse_response(raw).unwrap();
+        assert_eq!(d.cause, "c");
+        assert_eq!(d.confidence, "low");
+    }
+
+    #[test]
+    fn normalizes_unknown_enum_values() {
+        let raw = r#"{"cause":"x","suggestions":["a"],"confidence":"wibble","category":"nonsense"}"#;
+        let d = parse_response(raw).unwrap();
+        assert_eq!(d.confidence, "medium");
+        assert_eq!(d.category, "other");
+    }
+
+    #[test]
+    fn rejects_missing_fields() {
+        let raw = r#"{"cause":"","suggestions":["a"],"confidence":"high","category":"other"}"#;
+        assert!(parse_response(raw).is_err());
+        let raw = r#"{"cause":"x","suggestions":[],"confidence":"high","category":"other"}"#;
+        assert!(parse_response(raw).is_err());
+    }
+
+    #[test]
+    fn format_plain_contains_all_parts() {
+        let d = ErrorDiagnosis {
+            cause: "missing column".into(),
+            suggestions: vec!["add col".into(), "skip table".into()],
+            confidence: "high".into(),
+            category: "constraint".into(),
+        };
+        let s = d.format();
+        assert!(s.contains("AI Error Diagnosis"));
+        assert!(s.contains("missing column"));
+        assert!(s.contains("1. add col"));
+        assert!(s.contains("2. skip table"));
+        assert!(s.contains("Confidence: high"));
+        assert!(s.contains("Category: constraint"));
+    }
+
+    #[test]
+    fn format_boxed_has_consistent_width() {
+        let d = ErrorDiagnosis {
+            cause: "x".into(),
+            suggestions: vec!["a".into()],
+            confidence: "high".into(),
+            category: "other".into(),
+        };
+        let s = d.format_boxed();
+        // First and last lines must be top/bottom borders of the fixed width.
+        let first = s.lines().next().unwrap();
+        let last = s.lines().last().unwrap();
+        assert!(first.starts_with('┌'));
+        assert!(first.ends_with('┐'));
+        assert!(last.starts_with('└'));
+        assert!(last.ends_with('┘'));
+    }
+
+    #[test]
+    fn hash_is_stable_and_16_bytes_hex() {
+        let h1 = hash_error("some error");
+        let h2 = hash_error("some error");
+        let h3 = hash_error("different error");
+        assert_eq!(h1, h2);
+        assert_ne!(h1, h3);
+        assert_eq!(h1.len(), 32); // 16 bytes hex = 32 chars
+    }
+
+    #[test]
+    fn handler_callback_fires_when_registered() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let counter = Arc::new(AtomicUsize::new(0));
+        let c = counter.clone();
+        set_diagnosis_handler(Some(Arc::new(move |_: &ErrorDiagnosis| {
+            c.fetch_add(1, Ordering::SeqCst);
+        })));
+
+        let d = ErrorDiagnosis {
+            cause: "x".into(),
+            suggestions: vec!["a".into()],
+            confidence: "high".into(),
+            category: "other".into(),
+        };
+        emit_diagnosis(&d);
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+        set_diagnosis_handler(None);
+    }
+}

--- a/crates/dmt-rs/src/ai/mod.rs
+++ b/crates/dmt-rs/src/ai/mod.rs
@@ -8,12 +8,17 @@
 
 mod cache;
 mod config;
+mod errordiag;
 mod mapper;
 mod prompt;
 mod provider;
 
 pub use cache::TypeCache;
 pub use config::{AiConfig, AiProvider, GlobalConfig};
+pub use errordiag::{
+    emit_diagnosis, set_diagnosis_handler, DiagnosisHandler, ErrorContext, ErrorDiagnoser,
+    ErrorDiagnosis,
+};
 pub use mapper::AiTypeMapper;
 pub use prompt::PromptContext;
-pub use provider::{AiProviderClient, create_provider};
+pub use provider::{create_provider, AiProviderClient};

--- a/crates/dmt-rs/src/ai/provider.rs
+++ b/crates/dmt-rs/src/ai/provider.rs
@@ -19,6 +19,12 @@ pub trait AiProviderClient: Send + Sync {
         scale: i32,
         context: &PromptContext,
     ) -> Result<String>;
+
+    /// Send a system+user prompt and return the raw completion text.
+    ///
+    /// Used by error diagnosis and other features that need free-form LLM
+    /// responses, not just type names.
+    async fn complete_text(&self, system: &str, user: &str, max_tokens: u32) -> Result<String>;
 }
 
 /// Create an AI provider client from config.
@@ -160,6 +166,48 @@ impl AiProviderClient for AnthropicClient {
             ))
         })
     }
+
+    async fn complete_text(&self, system: &str, user: &str, max_tokens: u32) -> Result<String> {
+        let request = AnthropicRequest {
+            model: self.model.clone(),
+            max_tokens,
+            system: system.to_string(),
+            messages: vec![AnthropicMessage {
+                role: "user".to_string(),
+                content: user.to_string(),
+            }],
+        };
+
+        let url = format!("{}/v1/messages", self.base_url);
+
+        debug!("AI complete_text request (max_tokens={})", max_tokens);
+
+        let response = self.http
+            .post(&url)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("content-type", "application/json")
+            .json(&request)
+            .timeout(std::time::Duration::from_secs(30))
+            .send()
+            .await
+            .map_err(|e| MigrateError::Config(format!("AI API request failed: {}", e)))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(MigrateError::Config(format!(
+                "AI API returned {}: {}", status, body
+            )));
+        }
+
+        let body: AnthropicResponse = response
+            .json()
+            .await
+            .map_err(|e| MigrateError::Config(format!("AI API response parse error: {}", e)))?;
+
+        Ok(body.content.first().map(|c| c.text.clone()).unwrap_or_default())
+    }
 }
 
 // --- OpenAI-Compatible Client (OpenAI, Ollama, LM Studio) ---
@@ -265,5 +313,52 @@ impl AiProviderClient for OpenAiCompatibleClient {
                 "AI returned invalid type mapping for '{}': '{}'", source_type, raw
             ))
         })
+    }
+
+    async fn complete_text(&self, system: &str, user: &str, max_tokens: u32) -> Result<String> {
+        let request = OpenAiRequest {
+            model: self.model.clone(),
+            max_tokens,
+            messages: vec![
+                OpenAiMessage { role: "system".to_string(), content: system.to_string() },
+                OpenAiMessage { role: "user".to_string(), content: user.to_string() },
+            ],
+        };
+
+        let url = format!("{}/v1/chat/completions", self.base_url);
+
+        debug!("AI complete_text request (max_tokens={})", max_tokens);
+
+        let mut req = self.http
+            .post(&url)
+            .header("content-type", "application/json")
+            .json(&request)
+            .timeout(std::time::Duration::from_secs(30));
+
+        if !self.api_key.is_empty() {
+            req = req.header("authorization", format!("Bearer {}", self.api_key));
+        }
+
+        let response = req
+            .send()
+            .await
+            .map_err(|e| MigrateError::Config(format!("AI API request failed: {}", e)))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(MigrateError::Config(format!(
+                "AI API returned {}: {}", status, body
+            )));
+        }
+
+        let body: OpenAiResponse = response
+            .json()
+            .await
+            .map_err(|e| MigrateError::Config(format!("AI API response parse error: {}", e)))?;
+
+        Ok(body.choices.first()
+            .map(|c| c.message.content.clone())
+            .unwrap_or_default())
     }
 }

--- a/crates/dmt-rs/src/orchestrator/mod.rs
+++ b/crates/dmt-rs/src/orchestrator/mod.rs
@@ -41,6 +41,11 @@ pub struct Orchestrator {
     /// AI provider configuration.
     #[cfg(feature = "ai")]
     ai_config: Option<crate::ai::AiConfig>,
+    /// AI error diagnoser (mirrors Go dmt's DiagnoseSchemaError). Instantiated
+    /// lazily on first use so we don't pay the HTTP-client cost unless a DDL
+    /// actually fails.
+    #[cfg(feature = "ai")]
+    error_diagnoser: tokio::sync::OnceCell<Option<std::sync::Arc<crate::ai::ErrorDiagnoser>>>,
 }
 
 /// Result of a migration run.
@@ -316,6 +321,8 @@ impl Orchestrator {
             ai_cache: None,
             #[cfg(feature = "ai")]
             ai_config: None,
+            #[cfg(feature = "ai")]
+            error_diagnoser: tokio::sync::OnceCell::new(),
         })
     }
 
@@ -324,6 +331,8 @@ impl Orchestrator {
     /// This wraps all registered type mappers with an AI fallback layer.
     /// Unknown types will be resolved via the configured LLM provider
     /// during the warm-up phase (after schema extraction, before DDL generation).
+    /// Also enables AI error diagnosis — failed DDL statements will be
+    /// analyzed and suggestions emitted via the registered diagnosis handler.
     #[cfg(feature = "ai")]
     pub fn with_ai_config(mut self, ai_config: &crate::ai::AiConfig) -> Self {
         let cache = std::sync::Arc::new(crate::ai::TypeCache::load(&ai_config.cache_path()));
@@ -335,6 +344,66 @@ impl Orchestrator {
             ai_config.provider
         );
         self
+    }
+
+    /// Lazily construct (and memoize) the error diagnoser. Returns `None`
+    /// if AI is not configured or provider construction fails.
+    #[cfg(feature = "ai")]
+    async fn get_error_diagnoser(&self) -> Option<std::sync::Arc<crate::ai::ErrorDiagnoser>> {
+        self.error_diagnoser
+            .get_or_init(|| async {
+                let ai_config = self.ai_config.as_ref()?;
+                match crate::ai::create_provider(ai_config) {
+                    Ok(boxed) => {
+                        let provider: std::sync::Arc<dyn crate::ai::AiProviderClient> =
+                            std::sync::Arc::from(boxed);
+                        debug!("AI error diagnosis enabled");
+                        Some(std::sync::Arc::new(crate::ai::ErrorDiagnoser::new(provider)))
+                    }
+                    Err(e) => {
+                        debug!("AI error diagnoser unavailable: {}", e);
+                        None
+                    }
+                }
+            })
+            .await
+            .clone()
+    }
+
+    /// Fire-and-emit AI diagnosis for a DDL/schema error. No-op if AI is
+    /// not configured. Mirrors Go dmt's `DiagnoseSchemaError`.
+    #[cfg(feature = "ai")]
+    async fn diagnose_schema_error(
+        &self,
+        operation: &str,
+        table: &crate::core::schema::Table,
+        err: &crate::error::MigrateError,
+    ) {
+        let Some(diag) = self.get_error_diagnoser().await else {
+            return;
+        };
+        let ctx = crate::ai::ErrorContext {
+            error_message: format!("{}: {}", operation, err),
+            table_name: table.name.clone(),
+            table_schema: table.schema.clone(),
+            columns: table.columns.clone(),
+            source_db_type: self.source.db_type().to_string(),
+            target_db_type: self.target.db_type().to_string(),
+            target_mode: format!("{:?}", self.config.migration.target_mode),
+        };
+        match diag.diagnose(&ctx).await {
+            Ok(d) => crate::ai::emit_diagnosis(&d),
+            Err(e) => debug!("AI error diagnosis unavailable: {}", e),
+        }
+    }
+
+    #[cfg(not(feature = "ai"))]
+    async fn diagnose_schema_error(
+        &self,
+        _operation: &str,
+        _table: &crate::core::schema::Table,
+        _err: &crate::error::MigrateError,
+    ) {
     }
 
     /// Enable progress reporting to stderr as JSON lines.
@@ -819,14 +888,19 @@ impl Orchestrator {
                 for (i, table) in tables.iter().enumerate() {
                     let table_name = table.full_name();
                     info!("Preparing table {}/{}: {}", i + 1, tables.len(), table_name);
-                    prep_target.drop_table(target_schema, &table.name).await?;
+                    if let Err(e) = prep_target.drop_table(target_schema, &table.name).await {
+                        self.diagnose_schema_error("DROP TABLE", table, &e).await;
+                        return Err(e);
+                    }
 
-                    if self.config.migration.use_unlogged_tables {
-                        prep_target
-                            .create_table_unlogged(table, target_schema)
-                            .await?;
+                    let create_result = if self.config.migration.use_unlogged_tables {
+                        prep_target.create_table_unlogged(table, target_schema).await
                     } else {
-                        prep_target.create_table(table, target_schema).await?;
+                        prep_target.create_table(table, target_schema).await
+                    };
+                    if let Err(e) = create_result {
+                        self.diagnose_schema_error("CREATE TABLE", table, &e).await;
+                        return Err(e);
                     }
                 }
             }
@@ -842,14 +916,19 @@ impl Orchestrator {
                     }
 
                     if !prep_target.table_exists(target_schema, &table.name).await? {
-                        if self.config.migration.use_unlogged_tables {
-                            prep_target
-                                .create_table_unlogged(table, target_schema)
-                                .await?;
+                        let create_result = if self.config.migration.use_unlogged_tables {
+                            prep_target.create_table_unlogged(table, target_schema).await
                         } else {
-                            prep_target.create_table(table, target_schema).await?;
+                            prep_target.create_table(table, target_schema).await
+                        };
+                        if let Err(e) = create_result {
+                            self.diagnose_schema_error("CREATE TABLE", table, &e).await;
+                            return Err(e);
                         }
-                        prep_target.create_primary_key(table, target_schema).await?;
+                        if let Err(e) = prep_target.create_primary_key(table, target_schema).await {
+                            self.diagnose_schema_error("CREATE PRIMARY KEY", table, &e).await;
+                            return Err(e);
+                        }
                     } else {
                         // For existing tables, ensure primary key exists (required for upsert)
                         if !prep_target
@@ -860,7 +939,10 @@ impl Orchestrator {
                                 "Adding missing primary key to existing table {}",
                                 table_name
                             );
-                            prep_target.create_primary_key(table, target_schema).await?;
+                            if let Err(e) = prep_target.create_primary_key(table, target_schema).await {
+                                self.diagnose_schema_error("CREATE PRIMARY KEY", table, &e).await;
+                                return Err(e);
+                            }
                         }
 
                         // Drop non-PK indexes for faster upserts (only recreated if create_indexes is enabled)


### PR DESCRIPTION
## Summary
- Mirrors Go dmt's `ai_errordiag.go`: when AI is configured and a DDL fails, the error is sent to the configured LLM with schema context; the structured response (cause + 2-3 suggestions + confidence + 6-category taxonomy) is cached by SHA-256 of the error message and emitted via a pluggable handler.
- New `ai/errordiag.rs` module (`ErrorDiagnosis`, `ErrorDiagnoser`, `DiagnosisHandler`, `emit_diagnosis`, `set_diagnosis_handler`). Extends `AiProviderClient` trait with `complete_text(system, user, max_tokens)` so the diagnoser reuses existing HTTP plumbing. Wired into `Orchestrator::prepare_target` for `DROP TABLE` / `CREATE TABLE` / `CREATE PRIMARY KEY` in both drop_recreate and upsert paths.
- Activation: no flag or new config field. Reuses the existing `ai:` section in `~/.dmt-rs/dmt-rs-config.yaml` — parity with Go dmt's gating on `aiMapper != nil`. Lazily instantiates the diagnoser on first failure, so zero cost until a DDL fails.

## Follow-ups (intentionally out of scope)
- Finalize-phase spawned DDL sites (PK in finalize for MSSQL targets, index/FK/check warn paths). Needs pre-spawn capture of diagnoser + source/target db type strings, cloned into each `tokio::spawn`.
- TransferEngine writer error sites (`transfer/mod.rs:525`).
- TUI handler registration (the global `set_diagnosis_handler` exists but the TUI doesn't register one yet, so both CLI and TUI currently get the `tracing::warn` boxed fallback).

## Test plan
- [x] `cargo test --all-features` passes (371 tests, 8 new)
- [x] `cargo build --release -p dmt-rs-cli --features mysql,tui,ai` succeeds
- [x] `cargo build -p dmt-rs` (no ai feature) still compiles — stub path
- [x] `cargo clippy --all-features` produces no new warnings (7 preexisting warnings unchanged)
- [ ] Smoke test against a real failing migration (e.g., point at a target missing permissions; verify diagnosis emits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)