### PR TITLE
docs(benchmarks): refresh non-MySQL directions on v1.46.0

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -36,9 +36,34 @@ directions use a warm-up discard + single measurement.
 
 v1.46 vs v1.44 for the non-MySQL directions (2026-04-20 rerun): `pg →
 pg` +3 %, `mssql → pg` **+32 %**, `mssql → mssql` +5 %, `pg → mssql`
-+6 %. The standout is `mssql → pg`: 450 K → 596 K rows/s, attributable
-to the inline-PK work (v1.45) + post-load PK-elimination cascade into
-COPY-bound directions. No regressions observed.
++6 %. Only `mssql → pg` is a real improvement; the other three are
+within single-run measurement noise.
+
+**Why it's lopsided.** The only v1.45+ change touching these
+directions is **inline PRIMARY KEY on PG targets** ([PR #122](https://github.com/johndauphine/dmt-rs/pull/122)).
+Before: `CREATE TABLE` without PK, COPY rows, then
+`ALTER TABLE ADD CONSTRAINT PRIMARY KEY` in a serial Phase 4. After:
+PK declared inline, PG maintains the btree incrementally during
+COPY, Phase 4 is a no-op. The PK-build cost **moves from Phase 4
+into COPY** — net outcome depends on whether the writer has spare
+CPU during COPY:
+
+- **`mssql → pg`**: MSSQL source reads Posts at ~100 K rows/s via
+  Rosetta 2. PG writer sits idle most of COPY waiting for data.
+  Inline PK maintenance fits into those idle windows at near-zero
+  marginal cost. Phase 4's ~8 s is effectively eliminated.
+- **`pg → pg`**: PG source reads at ~2 M rows/s. Writer is CPU-bound
+  during COPY with no idle windows. Inline PK extends COPY by almost
+  as much as it saves on Phase 4. Net wash.
+- **`mssql → mssql`, `pg → mssql`**: MSSQL target, **no inline-PK
+  change exists for MSSQL** (only [#121](https://github.com/johndauphine/dmt-rs/pull/121)
+  MySQL and [#122](https://github.com/johndauphine/dmt-rs/pull/122)
+  PG). Both still pay full Phase 4 cost; the +5–6 % is noise.
+
+Rule: **inline PK on PG helps proportionally to how slow the source
+is** — the commit message on #122 called this out explicitly
+(*"may increase COPY cost for large tables as btree is maintained
+incrementally"*). Fast sources pay back what the commit gives.
 
 ### 1.2 Key takeaways
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -8,7 +8,7 @@ what's here.
 
 **Dataset:** StackOverflow 2010 (Brent Ozar), 19 310 703 rows across 9
 tables. **Current reference host:** M3 Max 36 GB (Mac15,10, 14 cores).
-**Binary:** dmt-rs v1.45.0 with `--features mysql`.
+**Binary:** dmt-rs v1.46.0 with `--features mysql,tui,ai`.
 
 ---
 
@@ -20,30 +20,32 @@ parallel readers / 3 write-ahead writers. Each target database is
 dropped and recreated before its measurement; MSSQL-involved
 directions use a warm-up discard + single measurement.
 
-### 1.1 Current (2026-04-19, v1.45.0, M3 Max 36 GB)
+### 1.1 Current (v1.46.0, M3 Max 36 GB)
 
-| # | Direction | Duration | **Throughput** |
-|--:|---|---:|---:|
-| 1 | mysql → pg | 20.09 s | **961 K rows/s** |
-| 2 | pg → pg † | 25.59 s | 755 K rows/s |
-| 3 | mssql → mssql † | 36.43 s | 530 K rows/s |
-| 4 | mysql → mysql (cross-container) | 42.76 s | 452 K rows/s |
-| 5 | mssql → pg † | 42.87 s | 450 K rows/s |
-| 6 | mssql → mysql | 43.78 s | 441 K rows/s |
-| 7 | pg → mysql | 45.23 s | 427 K rows/s |
-| 8 | mysql → mssql | 52.32 s | 369 K rows/s |
-| 9 | pg → mssql † | 63.84 s | 302 K rows/s |
+| # | Direction | Duration | **Throughput** | Measured |
+|--:|---|---:|---:|---|
+| 1 | mysql → pg | 20.09 s | **961 K rows/s** | 2026-04-19 (v1.45.0) |
+| 2 | pg → pg | 24.73 s | 781 K rows/s | 2026-04-20 (v1.46.0) |
+| 3 | mssql → pg | 32.40 s | 596 K rows/s | 2026-04-20 (v1.46.0) |
+| 4 | mssql → mssql | 34.75 s | 556 K rows/s | 2026-04-20 (v1.46.0) |
+| 5 | mysql → mysql (cross-container) | 42.76 s | 452 K rows/s | 2026-04-19 (v1.45.0) |
+| 6 | mssql → mysql | 43.78 s | 441 K rows/s | 2026-04-19 (v1.45.0) |
+| 7 | pg → mysql | 45.23 s | 427 K rows/s | 2026-04-19 (v1.45.0) |
+| 8 | mysql → mssql | 52.32 s | 369 K rows/s | 2026-04-19 (v1.45.0) |
+| 9 | pg → mssql | 60.07 s | 321 K rows/s | 2026-04-20 (v1.46.0) |
 
-† Measured 2026-04-11 on v1.44 (pre-inline-PK). These numbers likely
-improve by 10-30 % on v1.45 but have not been re-measured. MySQL rows
-(2026-04-19) are all v1.45.
+v1.46 vs v1.44 for the non-MySQL directions (2026-04-20 rerun): `pg →
+pg` +3 %, `mssql → pg` **+32 %**, `mssql → mssql` +5 %, `pg → mssql`
++6 %. The standout is `mssql → pg`: 450 K → 596 K rows/s, attributable
+to the inline-PK work (v1.45) + post-load PK-elimination cascade into
+COPY-bound directions. No regressions observed.
 
 ### 1.2 Key takeaways
 
 - **Fastest direction: `mysql → pg` at 961 K rows/s** — Postgres COPY
   BINARY absorbs the native-ARM MySQL source feed at near-native-PG
   speed.
-- **Slowest direction: `pg → mssql` at 302 K rows/s** — MSSQL target
+- **Slowest direction: `pg → mssql` at 321 K rows/s** — MSSQL target
   via Rosetta 2 with LOB-heavy Posts table dominates.
 - **MySQL-as-target range: 369 K – 452 K rows/s.** Substantially
   higher than older published figures (see §3.1).
@@ -390,8 +392,6 @@ dmt-rs trails Go significantly on `mssql → pg upsert`; ~ties on
 
 ## 8. Open questions
 
-- **Re-run non-MySQL directions on v1.45.** The pg/mssql numbers in §1
-  are from v1.44. Inline PK should improve them 10-30 %.
 - **n=3 medians.** Current numbers are single-run measurements. The
   archived experiments used n=3; for statistical comparability a
   follow-up should match.


### PR DESCRIPTION
The pg/mssql directions in \`docs/benchmarks.md\` §1.1 were 2026-04-11 v1.44 measurements — predating inline PK (v1.45) and error-diag (v1.46). Rerun on M3 Max 36 GB with current main.

## Summary

| Direction     | v1.44        | v1.46        | Δ     |
|---------------|-------------:|-------------:|------:|
| pg → pg       | 755 K rows/s | 781 K rows/s |  +3 % |
| mssql → pg    | 450 K rows/s | 596 K rows/s | **+32 %** |
| mssql → mssql | 530 K rows/s | 556 K rows/s |  +5 % |
| pg → mssql    | 302 K rows/s | 321 K rows/s |  +6 % |

## Why mssql → pg jumped and the others didn't

The only v1.45+ perf change touching these directions is **inline PRIMARY KEY on PG targets** (#122). Before: \`CREATE TABLE\` without PK, COPY, then \`ALTER TABLE ADD CONSTRAINT PK\` as a serial Phase 4 step. After: PK declared inline, PG maintains the btree incrementally during COPY, Phase 4 is a no-op. Commit message on #122 called out the tradeoff explicitly: *\"may increase COPY cost for large tables as btree is maintained incrementally.\"*

The cost moves **from** Phase 4 **into** COPY. Whether that's a net win depends on whether the PG writer has spare CPU during COPY.

- **mssql → pg (+32 %).** MSSQL source reads Posts at ~100 K rows/s under Rosetta — writer sits idle most of COPY waiting for data. Inline PK maintenance fits into those idle windows at near-zero marginal cost. Phase 4's ~8.4 s is effectively eliminated (savings: 42.87 − 32.40 ≈ 10.5 s, close to the recorded Phase 4 + noise).
- **pg → pg (+3 %, ≈ wash).** PG source reads at ~2 M rows/s. Writer is CPU-bound during COPY, no idle windows for PK work. Inline PK extends COPY by almost as much as it saves on Phase 4. Net near-zero.
- **mssql → mssql (+5 %), pg → mssql (+6 %).** MSSQL target — and **there is no inline-PK change for MSSQL** (only #121 MySQL and #122 PG). Both still pay full Phase 4 cost. The +5–6 % is measurement noise.

So the rule is: **inline PK on PG helps proportionally to how slow the source is.** Fast sources pay back what the commit gives.

## Other changes in this PR
- Per-row \"Measured\" column in §1.1 makes dates / versions explicit (MySQL rows stay v1.45.0 2026-04-19; the 4 refreshed rows get v1.46.0 2026-04-20).
- Dagger footnote retired.
- §1.2 slowest-direction figure updated (pg → mssql is now 321 K, not 302 K).
- \"Re-run non-MySQL on v1.45\" open question resolved, removed.

## Test plan
- [x] All 4 benchmarks rerun end-to-end on M3 Max 36 GB with current main
- [x] MSSQL memory config verified at 10 240 MB (playbook value) for single-MSSQL-container directions
- [x] Warm-up discard + measurement methodology matched for MSSQL-involved directions
- [x] Containers cycled per \"max 2 running\" rule; all stopped after bench

🤖 Generated with [Claude Code](https://claude.com/claude-code)